### PR TITLE
fix no configured schedule rule

### DIFF
--- a/app.go
+++ b/app.go
@@ -254,7 +254,7 @@ func (app *App) LoadStateMachine(ctx context.Context) (*StateMachine, error) {
 	return stateMachine, nil
 }
 
-func (app *App) LoadScheduleRules(ctx context.Context) (ScheduleRules, error) {
+func (app *App) LoadScheduleRules(ctx context.Context, stateMachineArn string) (ScheduleRules, error) {
 	rules := make([]*ScheduleRule, 0, len(app.cfg.Schedule))
 	for _, cfg := range app.cfg.Schedule {
 		rule := &ScheduleRule{
@@ -276,7 +276,7 @@ func (app *App) LoadScheduleRules(ctx context.Context) (ScheduleRules, error) {
 			rule.Targets[0].Id = aws.String(cfg.ID)
 		}
 		rule.Tags[tagManagedBy] = appName
-		rule.SetStateMachineArn("[state machine arn]")
+		rule.SetStateMachineArn(stateMachineArn)
 		rules = append(rules, rule)
 	}
 	return rules, nil

--- a/aws_test.go
+++ b/aws_test.go
@@ -37,6 +37,7 @@ type mockAWSClient struct {
 	ListTargetsByRuleFunc     func(ctx context.Context, params *eventbridge.ListTargetsByRuleInput, optFns ...func(*eventbridge.Options)) (*eventbridge.ListTargetsByRuleOutput, error)
 	PutTargetsFunc            func(ctx context.Context, params *eventbridge.PutTargetsInput, optFns ...func(*eventbridge.Options)) (*eventbridge.PutTargetsOutput, error)
 	DeleteRuleFunc            func(ctx context.Context, params *eventbridge.DeleteRuleInput, optFns ...func(*eventbridge.Options)) (*eventbridge.DeleteRuleOutput, error)
+	RemoveTargetsFunc         func(ctx context.Context, params *eventbridge.RemoveTargetsInput, optFns ...func(*eventbridge.Options)) (*eventbridge.RemoveTargetsOutput, error)
 	EBListTagsForResourceFunc func(ctx context.Context, params *eventbridge.ListTagsForResourceInput, optFns ...func(*eventbridge.Options)) (*eventbridge.ListTagsForResourceOutput, error)
 	ListRuleNamesByTargetFunc func(ctx context.Context, params *eventbridge.ListRuleNamesByTargetInput, optFns ...func(*eventbridge.Options)) (*eventbridge.ListRuleNamesByTargetOutput, error)
 	EBTagResourceFunc         func(ctx context.Context, params *eventbridge.TagResourceInput, optFns ...func(*eventbridge.Options)) (*eventbridge.TagResourceOutput, error)
@@ -54,6 +55,7 @@ type mockClientCallCount struct {
 	ListTargetsByRule     int
 	PutTargets            int
 	DeleteRule            int
+	RemoveTargets         int
 	ListRuleNamesByTarget int
 
 	SFnListTagsForResource int
@@ -76,6 +78,7 @@ func (m *mockClientCallCount) Reset() {
 	m.ListTargetsByRule = 0
 	m.PutTargets = 0
 	m.DeleteRule = 0
+	m.RemoveTargets = 0
 	m.ListRuleNamesByTarget = 0
 
 	m.SFnListTagsForResource = 0
@@ -204,6 +207,13 @@ func (m *mockEBClient) DeleteRule(ctx context.Context, params *eventbridge.Delet
 	}
 	return m.aws.DeleteRuleFunc(ctx, params, optFns...)
 }
+func (m *mockEBClient) RemoveTargets(ctx context.Context, params *eventbridge.RemoveTargetsInput, optFns ...func(*eventbridge.Options)) (*eventbridge.RemoveTargetsOutput, error) {
+	m.aws.CallCount.RemoveTargets++
+	if m.aws.RemoveTargetsFunc == nil {
+		return nil, errors.New("unexpected Call RemoveTargets")
+	}
+	return m.aws.RemoveTargetsFunc(ctx, params, optFns...)
+}
 
 func (m *mockEBClient) ListTagsForResource(ctx context.Context, params *eventbridge.ListTagsForResourceInput, optFns ...func(*eventbridge.Options)) (*eventbridge.ListTagsForResourceOutput, error) {
 	m.aws.CallCount.EBListTagsForResource++
@@ -297,6 +307,9 @@ func getDefaultMock(t *testing.T) *mockAWSClient {
 		DeleteRuleFunc: func(ctx context.Context, params *eventbridge.DeleteRuleInput, optFns ...func(*eventbridge.Options)) (*eventbridge.DeleteRuleOutput, error) {
 			return &eventbridge.DeleteRuleOutput{}, nil
 		},
+		RemoveTargetsFunc: func(ctx context.Context, params *eventbridge.RemoveTargetsInput, optFns ...func(*eventbridge.Options)) (*eventbridge.RemoveTargetsOutput, error) {
+			return &eventbridge.RemoveTargetsOutput{}, nil
+		},
 		ListTargetsByRuleFunc: func(ctx context.Context, params *eventbridge.ListTargetsByRuleInput, optFns ...func(*eventbridge.Options)) (*eventbridge.ListTargetsByRuleOutput, error) {
 			if !strings.Contains(*params.Rule, "Scheduled") {
 				return nil, errors.New("ResourceNotFoundException")
@@ -379,6 +392,9 @@ func (m *mockAWSClient) Overwrite(o *mockAWSClient) *mockAWSClient {
 	}
 	if o.DeleteRuleFunc != nil {
 		ret.DeleteRuleFunc = o.DeleteRuleFunc
+	}
+	if o.RemoveTargetsFunc != nil {
+		ret.RemoveTargetsFunc = o.RemoveTargetsFunc
 	}
 	if o.ListRuleNamesByTargetFunc != nil {
 		ret.ListRuleNamesByTargetFunc = o.ListRuleNamesByTargetFunc

--- a/create.go
+++ b/create.go
@@ -45,11 +45,11 @@ func (app *App) createScheduleRule(ctx context.Context, opt DeployOption) error 
 		log.Println("[debug] schedule rule is not set")
 		return nil
 	}
-	rules, err := app.LoadScheduleRules(ctx)
-	if err != nil {
-		return err
-	}
 	if opt.DryRun {
+		rules, err := app.LoadScheduleRules(ctx, "[state machine arn]")
+		if err != nil {
+			return err
+		}
 		log.Printf("[notice] create schedule rules %s\n%s", opt.DryRunString(), rules.String())
 		return nil
 	}
@@ -57,7 +57,10 @@ func (app *App) createScheduleRule(ctx context.Context, opt DeployOption) error 
 	if err != nil {
 		return fmt.Errorf("failed to get state machine arn: %w", err)
 	}
-	rules.SetStateMachineArn(stateMachineArn)
+	rules, err := app.LoadScheduleRules(ctx, stateMachineArn)
+	if err != nil {
+		return err
+	}
 	output, err := app.aws.DeployScheduleRules(ctx, rules)
 	if err != nil {
 		return err

--- a/delete_test.go
+++ b/delete_test.go
@@ -68,6 +68,7 @@ func TestDelete(t *testing.T) {
 				DescribeRule:           1,
 				SFnListTagsForResource: 1,
 				DeleteRule:             1,
+				RemoveTargets:          1,
 				ListTargetsByRule:      1,
 				EBListTagsForResource:  1,
 				ListRuleNamesByTarget:  1,

--- a/internal/jsonutil/util.go
+++ b/internal/jsonutil/util.go
@@ -56,11 +56,22 @@ func buildJSON(s interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var v map[string]interface{}
+	var v interface{}
 	if err := json.Unmarshal(bs, &v); err != nil {
 		return nil, err
 	}
-	return json.Marshal(deleteNilFromMap(v))
+	if v, ok := v.(map[string]interface{}); ok {
+		return json.Marshal(deleteNilFromMap(v))
+	}
+	if vs, ok := v.([]interface{}); ok {
+		for i := 0; i < len(vs); i++ {
+			if v, ok := vs[i].(map[string]interface{}); ok {
+				vs[i] = deleteNilFromMap(v)
+			}
+		}
+		return json.Marshal(vs)
+	}
+	return json.Marshal(v)
 }
 
 func deleteNilFromMap(v map[string]interface{}) map[string]interface{} {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -14,7 +14,7 @@ func Setup(w io.Writer, minLevel string) {
 		Levels:   []logutils.LogLevel{"debug", "info", "notice", "warn", "error"},
 		MinLevel: "info",
 		ModifierFuncs: []logutils.ModifierFunc{
-			nil,
+			logutils.Color(color.FgHiBlack),
 			logutils.Color(color.FgWhite),
 			logutils.Color(color.FgHiBlue),
 			logutils.Color(color.FgYellow),


### PR DESCRIPTION
Deletion did not work for rules that were not written in the configuration and were typed as ManagedBy:stepfunny in the tag, so fix it.