### PR TITLE
v0.6.0 is bridge version for configration format. output warning message

### DIFF
--- a/app.go
+++ b/app.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	eventbridgetypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
@@ -33,33 +32,13 @@ type newAppOptions struct {
 
 type NewAppOption func(*newAppOptions)
 
-func (o *newAppOptions) GetAWSConfig(ctx context.Context) (aws.Config, error) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	if o.awsCfg != nil {
-		return *o.awsCfg, nil
-	}
-	opts := []func(*awsConfig.LoadOptions) error{
-		awsConfig.WithRegion(o.cfg.AWSRegion),
-	}
-	if endpointsResolver, ok := o.cfg.EndpointResolver(); ok {
-		opts = append(opts, awsConfig.WithEndpointResolverWithOptions(endpointsResolver))
-	}
-	awsCfg, err := awsConfig.LoadDefaultConfig(ctx, opts...)
-	if err != nil {
-		return aws.Config{}, err
-	}
-	o.awsCfg = &awsCfg
-	return awsCfg, nil
-}
-
 func (o *newAppOptions) GetSFnService(ctx context.Context) (SFnService, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if o.sfnSvc != nil {
 		return o.sfnSvc, nil
 	}
-	awsCfg, err := o.GetAWSConfig(ctx)
+	awsCfg, err := o.cfg.LoadAWSConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +53,7 @@ func (o *newAppOptions) GetEventBridgeService(ctx context.Context) (EventBridgeS
 	if o.eventbridgeSvc != nil {
 		return o.eventbridgeSvc, nil
 	}
-	awsCfg, err := o.GetAWSConfig(ctx)
+	awsCfg, err := o.cfg.LoadAWSConfig(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/aws.go
+++ b/aws.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	eventbridgetypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
@@ -30,6 +31,11 @@ type SFnClient interface {
 	GetExecutionHistory(ctx context.Context, params *sfn.GetExecutionHistoryInput, optFns ...func(*sfn.Options)) (*sfn.GetExecutionHistoryOutput, error)
 	TagResource(ctx context.Context, params *sfn.TagResourceInput, optFns ...func(*sfn.Options)) (*sfn.TagResourceOutput, error)
 }
+
+type CloudWatchLogsClient interface {
+	cloudwatchlogs.DescribeLogGroupsAPIClient
+}
+
 type EventBridgeClient interface {
 	PutRule(ctx context.Context, params *eventbridge.PutRuleInput, optFns ...func(*eventbridge.Options)) (*eventbridge.PutRuleOutput, error)
 	ListRuleNamesByTarget(ctx context.Context, params *eventbridge.ListRuleNamesByTargetInput, optFns ...func(*eventbridge.Options)) (*eventbridge.ListRuleNamesByTargetOutput, error)

--- a/mock_test.go
+++ b/mock_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
@@ -637,4 +638,37 @@ func newMockApp(t *testing.T, path string, m *mocks) *stefunny.App {
 	)
 	require.NoError(t, err)
 	return app
+}
+
+type mockCloudWatchLogsClient struct {
+	mock.Mock
+	t *testing.T
+}
+
+func NewMockCloudWatchLogsClient(t *testing.T) *mockCloudWatchLogsClient {
+	t.Helper()
+	m := &mockCloudWatchLogsClient{
+		t: t,
+	}
+	m.Test(t)
+	return m
+}
+
+func (m *mockCloudWatchLogsClient) DescribeLogGroups(ctx context.Context, params *cloudwatchlogs.DescribeLogGroupsInput, optFns ...func(*cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, params, optFns)
+	} else {
+		args = m.Called(ctx, params)
+	}
+	output := args.Get(0)
+	err := args.Error(1)
+	if err == nil {
+		if o, ok := output.(*cloudwatchlogs.DescribeLogGroupsOutput); ok {
+			return o, nil
+		}
+		require.FailNow(m.t, "mock data is not *cloudwatchlogs.DescribeLogGroupsOutput")
+		return nil, errors.New("mock data is not *cloudwatchlogs.DescribeLogGroupsOutput")
+	}
+	return nil, err
 }

--- a/testdata/config/default_config.golden.json
+++ b/testdata/config/default_config.golden.json
@@ -1,0 +1,26 @@
+{
+  "required_version": "\u003ev0.0.0",
+  "aws_region": "us-east-1",
+  "state_machine": {
+    "definition": "{\n   \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",\n   \"StartAt\": \"Hello\",\n   \"States\": {\n      \"Hello\": {\n         \"Next\": \"World\",\n         \"Type\": \"Pass\"\n      },\n      \"World\": {\n         \"End\": true,\n         \"Result\": \"World\",\n         \"Type\": \"Pass\"\n      }\n   }\n}",
+    "logging_configuration": {
+      "destinations": [
+        {
+          "cloudwatch_logs_log_group": {
+            "log_group_arn": "arn:aws:logs:us-east-1:012345678901:log-group:/steps/hello"
+          }
+        }
+      ],
+      "include_execution_data": false,
+      "level": "ALL"
+    },
+    "name": "Hello",
+    "publish": false,
+    "role_arn": "arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role",
+    "tracing_configuration": {
+      "enabled": false
+    },
+    "type": "STANDARD"
+  },
+  "ConfigDir": "testdata"
+}

--- a/testdata/config/jsonnet.golden.json
+++ b/testdata/config/jsonnet.golden.json
@@ -1,0 +1,26 @@
+{
+  "required_version": "\u003e=v0.5.0",
+  "aws_region": "us-east-1",
+  "state_machine": {
+    "definition": "{\n   \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",\n   \"StartAt\": \"Hello\",\n   \"States\": {\n      \"Hello\": {\n         \"Next\": \"World\",\n         \"Type\": \"Pass\"\n      },\n      \"World\": {\n         \"End\": true,\n         \"Result\": \"World\",\n         \"Type\": \"Pass\"\n      }\n   }\n}",
+    "logging_configuration": {
+      "destinations": [
+        {
+          "cloudwatch_logs_log_group": {
+            "log_group_arn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/stepfunctions/Hello"
+          }
+        }
+      ],
+      "include_execution_data": false,
+      "level": "ALL"
+    },
+    "name": "Hello",
+    "publish": false,
+    "role_arn": "arn:aws:iam::123456789012:role/StepFunctions-Hello-Role",
+    "tracing_configuration": {
+      "enabled": false
+    },
+    "type": "STANDARD"
+  },
+  "ConfigDir": "testdata"
+}

--- a/testdata/config/log_level_off.golden.json
+++ b/testdata/config/log_level_off.golden.json
@@ -1,0 +1,19 @@
+{
+  "required_version": "\u003ev0.0.0",
+  "aws_region": "us-east-1",
+  "state_machine": {
+    "definition": "{\n   \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",\n   \"StartAt\": \"Hello\",\n   \"States\": {\n      \"Hello\": {\n         \"Next\": \"World\",\n         \"Type\": \"Pass\"\n      },\n      \"World\": {\n         \"End\": true,\n         \"Result\": \"World\",\n         \"Type\": \"Pass\"\n      }\n   }\n}",
+    "logging_configuration": {
+      "include_execution_data": false,
+      "level": "OFF"
+    },
+    "name": "Hello",
+    "publish": false,
+    "role_arn": "arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role",
+    "tracing_configuration": {
+      "enabled": false
+    },
+    "type": "STANDARD"
+  },
+  "ConfigDir": "testdata"
+}

--- a/testdata/config/old_type_config_v0.5.0.golden.json
+++ b/testdata/config/old_type_config_v0.5.0.golden.json
@@ -1,0 +1,26 @@
+{
+  "required_version": "\u003ev0.0.0",
+  "aws_region": "us-east-1",
+  "state_machine": {
+    "definition": "{\n   \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",\n   \"StartAt\": \"Hello\",\n   \"States\": {\n      \"Hello\": {\n         \"Next\": \"World\",\n         \"Type\": \"Pass\"\n      },\n      \"World\": {\n         \"End\": true,\n         \"Result\": \"World\",\n         \"Type\": \"Pass\"\n      }\n   }\n}",
+    "logging_configuration": {
+      "destinations": [
+        {
+          "cloudwatch_logs_log_group": {
+            "log_group_arn": "arn:aws:logs:us-east-1:000000000000:log-group:/aws/vendedlogs/states/Hello-Logs"
+          }
+        }
+      ],
+      "include_execution_data": false,
+      "level": "ALL"
+    },
+    "name": "Hello",
+    "publish": false,
+    "role_arn": "arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role",
+    "tracing_configuration": {
+      "enabled": true
+    },
+    "type": "STANDARD"
+  },
+  "ConfigDir": "testdata"
+}

--- a/testdata/config/tfstate_read.golden.json
+++ b/testdata/config/tfstate_read.golden.json
@@ -1,0 +1,35 @@
+{
+  "required_version": "\u003ev0.0.0",
+  "aws_region": "us-east-1",
+  "state_machine": {
+    "definition": "{\n   \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",\n   \"StartAt\": \"Hello\",\n   \"States\": {\n      \"Hello\": {\n         \"Next\": \"New\",\n         \"Type\": \"Pass\"\n      },\n      \"New\": {\n         \"Next\": \"World\",\n         \"Seconds\": 120,\n         \"Type\": \"Wait\"\n      },\n      \"World\": {\n         \"Comment\": \"great!!!\",\n         \"End\": true,\n         \"Parameters\": {\n            \"Bucket\": \"test-hoge\"\n         },\n         \"Resource\": \"arn:aws:states:::aws-sdk:s3:listObjects\",\n         \"Type\": \"Task\"\n      }\n   }\n}",
+    "logging_configuration": {
+      "destinations": [
+        {
+          "cloudwatch_logs_log_group": {
+            "log_group_arn": "arn:aws:logs:ap-northeast-1:000000000000:log-group:test"
+          }
+        }
+      ],
+      "include_execution_data": false,
+      "level": "FATAL"
+    },
+    "name": "Hello",
+    "publish": false,
+    "role_arn": "arn:aws:iam::000000000000:role/test",
+    "tracing_configuration": {
+      "enabled": false
+    },
+    "type": "STANDARD"
+  },
+  "tfstate": [
+    {
+      "path": "./terraform.tfstate"
+    },
+    {
+      "func_prefix": "second_",
+      "url": "./terraform.tfstate"
+    }
+  ],
+  "ConfigDir": "testdata"
+}

--- a/testdata/config/yaml.golden.json
+++ b/testdata/config/yaml.golden.json
@@ -1,0 +1,26 @@
+{
+  "required_version": "\u003ev0.0.0",
+  "aws_region": "us-east-1",
+  "state_machine": {
+    "definition": "{\"Comment\":\"A Hello World example of the Amazon States Language using Pass states\",\"StartAt\":\"Hello\",\"States\":{\"Hello\":{\"Next\":\"World\",\"Type\":\"Pass\"},\"World\":{\"End\":true,\"Result\":\"World\",\"Type\":\"Pass\"}}}",
+    "logging_configuration": {
+      "destinations": [
+        {
+          "cloudwatch_logs_log_group": {
+            "log_group_arn": "arn:aws:logs:us-east-1:012345678901:log-group:/steps/hello"
+          }
+        }
+      ],
+      "include_execution_data": false,
+      "level": "ALL"
+    },
+    "name": "Hello",
+    "publish": false,
+    "role_arn": "arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role",
+    "tracing_configuration": {
+      "enabled": false
+    },
+    "type": "STANDARD"
+  },
+  "ConfigDir": "testdata"
+}

--- a/testdata/config/yaml_config_with_jsonnet_def.golden.json
+++ b/testdata/config/yaml_config_with_jsonnet_def.golden.json
@@ -1,0 +1,26 @@
+{
+  "required_version": "\u003ev0.0.0",
+  "aws_region": "us-east-1",
+  "state_machine": {
+    "definition": "{\n   \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",\n   \"StartAt\": \"Hello\",\n   \"States\": {\n      \"Hello\": {\n         \"Next\": \"World\",\n         \"Type\": \"Pass\"\n      },\n      \"World\": {\n         \"End\": true,\n         \"Result\": \"World\",\n         \"Type\": \"Pass\"\n      }\n   }\n}",
+    "logging_configuration": {
+      "destinations": [
+        {
+          "cloudwatch_logs_log_group": {
+            "log_group_arn": "arn:aws:logs:us-east-1:012345678901:log-group:/steps/hello"
+          }
+        }
+      ],
+      "include_execution_data": false,
+      "level": "FATAL"
+    },
+    "name": "Hello",
+    "publish": false,
+    "role_arn": "arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role",
+    "tracing_configuration": {
+      "enabled": false
+    },
+    "type": "STANDARD"
+  },
+  "ConfigDir": "testdata"
+}

--- a/testdata/old_config.yaml
+++ b/testdata/old_config.yaml
@@ -1,0 +1,12 @@
+required_version: ">v0.0.0"
+
+state_machine:
+  name: Hello
+  definition: hello_world.asl.json
+  role_arn: arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role
+  logging:
+    level: ALL
+    destination:
+      log_group: /aws/vendedlogs/states/Hello-Logs
+  tracing:
+    enabled: true


### PR DESCRIPTION
render command is breaking changes. remaking
but config format, support old version.
if old version config render, output new version config format

```yaml 
required_version: ">v0.0.0"

state_machine:
  name: Hello
  definition: hello_world.asl.json
  role_arn: arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role
  logging:
    level: ALL
    destination:
      log_group: /aws/vendedlogs/states/Hello-Logs
  tracing:
    enabled: true
```

following output

```
$ go run cmd/stefunny/main.go render --config testdata/old_config.yaml config
2024/02/05 19:40:18 [warn] state_machine.logging is deprecated. Use state_machine.logging_configuration instead. (since v0.6.0)
2024/02/05 19:40:18 [warn] state_machine.tracing is deprecated. Use state_machine.tracing_configuration instead. (since v0.6.0)
required_version: '>v0.0.0'
aws_region: ap-northeast-1
state_machine:
    definition: hello_world.asl.json
    logging_configuration:
        destinations:
            - cloudwatch_logs_log_group:
                log_group_arn: arn:aws:logs:ap-northeast-1:012345678901:log-group:/aws/vendedlogs/states/Hello-Logs:*
        include_execution_data: false
        level: ALL
    name: Hello
    publish: false
    role_arn: arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role
    tracing_configuration:
        enabled: true
    type: STANDARD
  
```