### PR TITLE
Feature: On Deploy, publish version and create/update alias. implement Rollback

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -171,9 +171,6 @@ func (svc *SFnServiceImpl) DeployStateMachine(ctx context.Context, stateMachine 
 		log.Println("[debug] try create state machine")
 		cloned := stateMachine.CreateStateMachineInput
 		cloned.Publish = true
-		if cloned.VersionDescription == nil {
-			cloned.VersionDescription = aws.String(fmt.Sprintf("created by %s", appName))
-		}
 		createOutput, err := svc.client.CreateStateMachine(ctx, &cloned, optFns...)
 		if err != nil {
 			return nil, fmt.Errorf("create failed: %w", err)
@@ -209,10 +206,6 @@ func (svc *SFnServiceImpl) DeployStateMachine(ctx context.Context, stateMachine 
 
 func (svc *SFnServiceImpl) updateStateMachine(ctx context.Context, stateMachine *StateMachine, optFns ...func(*sfn.Options)) (*DeployStateMachineOutput, error) {
 	log.Println("[debug] try update state machine")
-	versionDesc := stateMachine.VersionDescription
-	if versionDesc == nil {
-		versionDesc = aws.String(fmt.Sprintf("updated by %s", appName))
-	}
 	output, err := svc.client.UpdateStateMachine(ctx, &sfn.UpdateStateMachineInput{
 		StateMachineArn:      stateMachine.StateMachineArn,
 		Definition:           stateMachine.Definition,
@@ -220,7 +213,7 @@ func (svc *SFnServiceImpl) updateStateMachine(ctx context.Context, stateMachine 
 		RoleArn:              stateMachine.RoleArn,
 		TracingConfiguration: stateMachine.TracingConfiguration,
 		Publish:              true,
-		VersionDescription:   versionDesc,
+		VersionDescription:   stateMachine.VersionDescription,
 	}, optFns...)
 	if err != nil {
 		return nil, err

--- a/aws.go
+++ b/aws.go
@@ -648,6 +648,9 @@ func (svc *SFnServiceImpl) DeleteStateMachine(ctx context.Context, stateMachine 
 		_, err := svc.client.DeleteStateMachine(ctx, &sfn.DeleteStateMachineInput{
 			StateMachineArn: stateMachine.StateMachineArn,
 		}, optFns...)
+		if err == nil {
+			return nil
+		}
 		var apiErr smithy.APIError
 		if !errors.As(err, &apiErr) {
 			log.Printf("[debug] unexpected error: %s", err.Error())
@@ -1371,12 +1374,12 @@ func (svc *SFnServiceImpl) startExecutionForExpress(ctx context.Context, stateMa
 	if err != nil {
 		return nil, err
 	}
-	succeded := syncOutput.Status == sfntypes.SyncExecutionStatusSucceeded
+	succeeded := syncOutput.Status == sfntypes.SyncExecutionStatusSucceeded
 	failed := syncOutput.Status == sfntypes.SyncExecutionStatusFailed
 	output := &StartExecutionOutput{
 		ExecutionArn: *syncOutput.ExecutionArn,
 		StartDate:    *syncOutput.StartDate,
-		Success:      &succeded,
+		Success:      &succeeded,
 		Failed:       &failed,
 		StopDate:     syncOutput.StopDate,
 	}

--- a/aws.go
+++ b/aws.go
@@ -26,7 +26,6 @@ type SFnClient interface {
 	ListStateMachineVersions(ctx context.Context, params *sfn.ListStateMachineVersionsInput, optFns ...func(*sfn.Options)) (*sfn.ListStateMachineVersionsOutput, error)
 	UpdateStateMachine(ctx context.Context, params *sfn.UpdateStateMachineInput, optFns ...func(*sfn.Options)) (*sfn.UpdateStateMachineOutput, error)
 	UpdateStateMachineAlias(ctx context.Context, params *sfn.UpdateStateMachineAliasInput, optFns ...func(*sfn.Options)) (*sfn.UpdateStateMachineAliasOutput, error)
-	PublishStateMachineVersion(ctx context.Context, params *sfn.PublishStateMachineVersionInput, optFns ...func(*sfn.Options)) (*sfn.PublishStateMachineVersionOutput, error)
 	DeleteStateMachine(ctx context.Context, params *sfn.DeleteStateMachineInput, optFns ...func(*sfn.Options)) (*sfn.DeleteStateMachineOutput, error)
 	DeleteStateMachineVersion(ctx context.Context, params *sfn.DeleteStateMachineVersionInput, optFns ...func(*sfn.Options)) (*sfn.DeleteStateMachineVersionOutput, error)
 	ListTagsForResource(ctx context.Context, params *sfn.ListTagsForResourceInput, optFns ...func(*sfn.Options)) (*sfn.ListTagsForResourceOutput, error)

--- a/aws.go
+++ b/aws.go
@@ -1333,7 +1333,7 @@ func (svc *SFnServiceImpl) StartExecution(ctx context.Context, stateMachine *Sta
 	}
 }
 
-func (svc *SFnServiceImpl) startExecutionForStandard(ctx context.Context, stateMachine *StateMachine, params *StartExecutionInput, optFns ...func(*sfn.Options)) (*StartExecutionOutput, error) {
+func (svc *SFnServiceImpl) startExecutionForStandard(ctx context.Context, stateMachine *StateMachine, params *StartExecutionInput, _ ...func(*sfn.Options)) (*StartExecutionOutput, error) {
 	output, err := svc.startExecution(ctx, stateMachine, params)
 	if err != nil {
 		return nil, err
@@ -1355,7 +1355,7 @@ func (svc *SFnServiceImpl) startExecutionForStandard(ctx context.Context, stateM
 	return output, nil
 }
 
-func (svc *SFnServiceImpl) startExecutionForExpress(ctx context.Context, stateMachine *StateMachine, params *StartExecutionInput, optFns ...func(*sfn.Options)) (*StartExecutionOutput, error) {
+func (svc *SFnServiceImpl) startExecutionForExpress(ctx context.Context, stateMachine *StateMachine, params *StartExecutionInput, _ ...func(*sfn.Options)) (*StartExecutionOutput, error) {
 	if params.Async {
 		output, err := svc.startExecution(ctx, stateMachine, params)
 		if err != nil {

--- a/aws.go
+++ b/aws.go
@@ -20,9 +20,15 @@ import (
 type SFnClient interface {
 	sfn.ListStateMachinesAPIClient
 	CreateStateMachine(ctx context.Context, params *sfn.CreateStateMachineInput, optFns ...func(*sfn.Options)) (*sfn.CreateStateMachineOutput, error)
+	CreateStateMachineAlias(ctx context.Context, params *sfn.CreateStateMachineAliasInput, optFns ...func(*sfn.Options)) (*sfn.CreateStateMachineAliasOutput, error)
 	DescribeStateMachine(ctx context.Context, params *sfn.DescribeStateMachineInput, optFns ...func(*sfn.Options)) (*sfn.DescribeStateMachineOutput, error)
+	DescribeStateMachineAlias(ctx context.Context, params *sfn.DescribeStateMachineAliasInput, optFns ...func(*sfn.Options)) (*sfn.DescribeStateMachineAliasOutput, error)
+	ListStateMachineVersions(ctx context.Context, params *sfn.ListStateMachineVersionsInput, optFns ...func(*sfn.Options)) (*sfn.ListStateMachineVersionsOutput, error)
 	UpdateStateMachine(ctx context.Context, params *sfn.UpdateStateMachineInput, optFns ...func(*sfn.Options)) (*sfn.UpdateStateMachineOutput, error)
+	UpdateStateMachineAlias(ctx context.Context, params *sfn.UpdateStateMachineAliasInput, optFns ...func(*sfn.Options)) (*sfn.UpdateStateMachineAliasOutput, error)
+	PublishStateMachineVersion(ctx context.Context, params *sfn.PublishStateMachineVersionInput, optFns ...func(*sfn.Options)) (*sfn.PublishStateMachineVersionOutput, error)
 	DeleteStateMachine(ctx context.Context, params *sfn.DeleteStateMachineInput, optFns ...func(*sfn.Options)) (*sfn.DeleteStateMachineOutput, error)
+	DeleteStateMachineVersion(ctx context.Context, params *sfn.DeleteStateMachineVersionInput, optFns ...func(*sfn.Options)) (*sfn.DeleteStateMachineVersionOutput, error)
 	ListTagsForResource(ctx context.Context, params *sfn.ListTagsForResourceInput, optFns ...func(*sfn.Options)) (*sfn.ListTagsForResourceOutput, error)
 	StartExecution(ctx context.Context, params *sfn.StartExecutionInput, optFns ...func(*sfn.Options)) (*sfn.StartExecutionOutput, error)
 	StartSyncExecution(ctx context.Context, params *sfn.StartSyncExecutionInput, optFns ...func(*sfn.Options)) (*sfn.StartSyncExecutionOutput, error)

--- a/aws_test.go
+++ b/aws_test.go
@@ -354,6 +354,26 @@ func TestSFnService_DeployStateMachine_CreateNewMachine(t *testing.T) {
 		},
 		nil,
 	).Once()
+	m.On("DescribeStateMachineAlias", mock.Anything, &sfn.DescribeStateMachineAliasInput{
+		StateMachineAliasArn: aws.String("arn:aws:states:us-east-1:123456789012:stateMachine:Hello:current"),
+	}).Return(
+		nil,
+		&sfntypes.ResourceNotFound{
+			Message: aws.String("not found"),
+		},
+	).Once()
+	m.On("CreateStateMachineAlias", mock.Anything, &sfn.CreateStateMachineAliasInput{
+		Name: aws.String("current"),
+		RoutingConfiguration: []sfntypes.RoutingConfigurationListItem{
+			{
+				StateMachineVersionArn: aws.String("arn:aws:states:us-east-1:123456789012:stateMachine:Hello:1"),
+				Weight:                 100,
+			},
+		},
+	}).Return(
+		&sfn.CreateStateMachineAliasOutput{},
+		nil,
+	).Once()
 
 	svc := stefunny.NewSFnService(m)
 	ctx := context.Background()
@@ -468,6 +488,26 @@ func TestSFnService_DeployStateMachine_UpdateStateMachine(t *testing.T) {
 			CreationDate:    stateMachine.CreationDate,
 			Status:          sfntypes.StateMachineStatusActive,
 		},
+		nil,
+	).Once()
+	m.On("DescribeStateMachineAlias", mock.Anything, &sfn.DescribeStateMachineAliasInput{
+		StateMachineAliasArn: aws.String("arn:aws:states:us-east-1:123456789012:stateMachine:Hello:current"),
+	}).Return(
+		&sfn.DescribeStateMachineAliasOutput{
+			StateMachineAliasArn: aws.String("arn:aws:states:us-east-1:123456789012:stateMachine:Hello:current"),
+		},
+		nil,
+	).Once()
+	m.On("UpdateStateMachineAlias", mock.Anything, &sfn.UpdateStateMachineAliasInput{
+		StateMachineAliasArn: aws.String("arn:aws:states:us-east-1:123456789012:stateMachine:Hello:current"),
+		RoutingConfiguration: []sfntypes.RoutingConfigurationListItem{
+			{
+				StateMachineVersionArn: aws.String("arn:aws:states:us-east-1:123456789012:stateMachine:Hello:2"),
+				Weight:                 100,
+			},
+		},
+	}).Return(
+		&sfn.UpdateStateMachineAliasOutput{},
 		nil,
 	).Once()
 

--- a/aws_test.go
+++ b/aws_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestSFnService_DescribeStateMachine_NotFound(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 
@@ -29,6 +30,7 @@ func TestSFnService_DescribeStateMachine_NotFound(t *testing.T) {
 }
 
 func TestSFnService_DescribeStateMachine_SuccessFirstFetch(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 
@@ -115,6 +117,7 @@ func TestSFnService_DescribeStateMachine_SuccessFirstFetch(t *testing.T) {
 }
 
 func TestSFnService_DescribeStateMachine_SuccessSecondFetch(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 
@@ -221,6 +224,7 @@ func TestSFnService_DescribeStateMachine_SuccessSecondFetch(t *testing.T) {
 }
 
 func TestSFnService_DescribeStateMachine_FailedOnListStateMachine(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	expectedErr := errors.New("this is testing")
@@ -232,6 +236,7 @@ func TestSFnService_DescribeStateMachine_FailedOnListStateMachine(t *testing.T) 
 }
 
 func TestSFnService_DescribeStateMachine_FailedOnDescribeStateMachine(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 
@@ -256,6 +261,7 @@ func TestSFnService_DescribeStateMachine_FailedOnDescribeStateMachine(t *testing
 }
 
 func TestSFnService_DescribeStateMachine_FailedOnListTagsForResource(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 
@@ -298,6 +304,7 @@ func TestSFnService_DescribeStateMachine_FailedOnListTagsForResource(t *testing.
 }
 
 func TestSFnService_DeployStateMachine_CreateNewMachine(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	stateMachine := &stefunny.StateMachine{
@@ -388,6 +395,7 @@ func TestSFnService_DeployStateMachine_CreateNewMachine(t *testing.T) {
 }
 
 func TestSFnService_DeployStateMachine_CreateStateMachineFailed(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	stateMachine := &stefunny.StateMachine{
@@ -425,6 +433,7 @@ func TestSFnService_DeployStateMachine_CreateStateMachineFailed(t *testing.T) {
 }
 
 func TestSFnService_DeployStateMachine_UpdateStateMachine(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	stateMachine := &stefunny.StateMachine{
@@ -523,6 +532,7 @@ func TestSFnService_DeployStateMachine_UpdateStateMachine(t *testing.T) {
 }
 
 func TestSFnService_DeployStateMachine_UpdateStateMachineFailed(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	stateMachine := &stefunny.StateMachine{
@@ -563,6 +573,7 @@ func TestSFnService_DeployStateMachine_UpdateStateMachineFailed(t *testing.T) {
 }
 
 func TestSFnService_DeployStateMachine_TagResourceFailed(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	stateMachine := &stefunny.StateMachine{
@@ -608,6 +619,7 @@ func TestSFnService_DeployStateMachine_TagResourceFailed(t *testing.T) {
 }
 
 func TestSFnService_DeleteStateMachine_Success(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	stateMachineArn := "arn:aws:states:us-east-1:123456789012:stateMachine:Hello"
@@ -624,6 +636,7 @@ func TestSFnService_DeleteStateMachine_Success(t *testing.T) {
 }
 
 func TestSFnService_DeleteStateMachine_Deleting(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	svc := stefunny.NewSFnService(m)
@@ -637,6 +650,7 @@ func TestSFnService_DeleteStateMachine_Deleting(t *testing.T) {
 }
 
 func TestSFnService_DeleteStateMachine_Failed(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	expectedErr := errors.New("this is testing")
@@ -651,6 +665,7 @@ func TestSFnService_DeleteStateMachine_Failed(t *testing.T) {
 }
 
 func TestSFnService_StartExecution_Success(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	m.On("StartExecution", mock.Anything, mock.MatchedBy(
@@ -683,6 +698,7 @@ func TestSFnService_StartExecution_Success(t *testing.T) {
 }
 
 func TestSFnService_StartExecution_Failed(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	expectedErr := errors.New("this is testing")
@@ -700,6 +716,7 @@ func TestSFnService_StartExecution_Failed(t *testing.T) {
 }
 
 func TestSFnService_WaitExecution_Success(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	m.On("DescribeExecution", mock.Anything, &sfn.DescribeExecutionInput{
@@ -750,6 +767,7 @@ func TestSFnService_WaitExecution_Success(t *testing.T) {
 }
 
 func TestSFnService_WaitExecution_ExecutionIsFailed(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	m.On("DescribeExecution", mock.Anything, &sfn.DescribeExecutionInput{
@@ -809,6 +827,7 @@ func TestSFnService_WaitExecution_ExecutionIsFailed(t *testing.T) {
 }
 
 func TestSFnService_WaitExecution_DescribeExecutionAPIFailed(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	expectedErr := errors.New("this is testing")
@@ -821,6 +840,7 @@ func TestSFnService_WaitExecution_DescribeExecutionAPIFailed(t *testing.T) {
 }
 
 func TestSFnService__WaitExectuion_GetHistoryAPIFailed(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	m.On("DescribeExecution", mock.Anything, mock.Anything).Return(&sfn.DescribeExecutionOutput{
@@ -841,6 +861,7 @@ func TestSFnService__WaitExectuion_GetHistoryAPIFailed(t *testing.T) {
 }
 
 func TestSFnService_WaitExecution_ContextCancelStopExection(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 
@@ -868,6 +889,7 @@ func TestSFnService_WaitExecution_ContextCancelStopExection(t *testing.T) {
 }
 
 func TestSFnService_WaitExecution_StopExecutionAPIFaild(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 
@@ -888,6 +910,7 @@ func TestSFnService_WaitExecution_StopExecutionAPIFaild(t *testing.T) {
 }
 
 func TestSFnService__StartSyncExecution_Success(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	m.On("StartSyncExecution", mock.Anything, mock.MatchedBy(
@@ -922,6 +945,7 @@ func TestSFnService__StartSyncExecution_Success(t *testing.T) {
 }
 
 func TestSFnService__StartSyncExecution_Failed(t *testing.T) {
+	LoggerSetup(t, "debug")
 	m := NewMockSFnClient(t)
 	defer m.AssertExpectations(t)
 	expectedErr := errors.New("this is testing")

--- a/aws_test.go
+++ b/aws_test.go
@@ -333,10 +333,8 @@ func TestSFnService_DeployStateMachine_CreateNewMachine(t *testing.T) {
 		stateMachine.CreateStateMachineInput.Tags = input.Tags
 		isPublish := assert.True(t, input.Publish)
 		stateMachine.CreateStateMachineInput.Publish = input.Publish
-		sameVersionDescription := assert.Equal(t, "created by stefunny", *input.VersionDescription)
-		stateMachine.CreateStateMachineInput.VersionDescription = input.VersionDescription
 		return assert.EqualValues(t, stateMachine.CreateStateMachineInput, *input) &&
-			result && isPublish && sameVersionDescription
+			result && isPublish
 	})).Return(&sfn.CreateStateMachineOutput{
 		StateMachineArn:        aws.String("arn:aws:states:us-east-1:123456789012:stateMachine:Hello"),
 		StateMachineVersionArn: aws.String("arn:aws:states:us-east-1:123456789012:stateMachine:Hello:1"),
@@ -371,7 +369,9 @@ func TestSFnService_DeployStateMachine_CreateNewMachine(t *testing.T) {
 			},
 		},
 	}).Return(
-		&sfn.CreateStateMachineAliasOutput{},
+		&sfn.CreateStateMachineAliasOutput{
+			StateMachineAliasArn: aws.String("arn:aws:states:us-east-1:123456789012:stateMachine:Hello:current"),
+		},
 		nil,
 	).Once()
 
@@ -462,7 +462,6 @@ func TestSFnService_DeployStateMachine_UpdateStateMachine(t *testing.T) {
 			LoggingConfiguration: stateMachine.LoggingConfiguration,
 			RoleArn:              stateMachine.RoleArn,
 			Publish:              true,
-			VersionDescription:   aws.String("updated by stefunny"),
 			TracingConfiguration: stateMachine.TracingConfiguration,
 		}, input)
 

--- a/cli.go
+++ b/cli.go
@@ -26,6 +26,7 @@ type CLI struct {
 	Init     InitOption            `cmd:"" help:"Initialize stefunny configuration" json:"init,omitempty"`
 	Delete   DeleteOption          `cmd:"" help:"Delete state machine and schedule rules" json:"delete,omitempty"`
 	Deploy   DeployCommandOption   `cmd:"" help:"Deploy state machine and schedule rules" json:"deploy,omitempty"`
+	Rollback RollbackOption        `cmd:"" help:"Rollback state machine" json:"rollback,omitempty"`
 	Schedule ScheduleCommandOption `cmd:"" help:"Enable or disable schedule rules" json:"schedule,omitempty"`
 	Render   RenderOption          `cmd:"" help:"Render state machine definition" json:"render,omitempty"`
 	Execute  ExecuteOption         `cmd:"" help:"Execute state machine" json:"execute,omitempty"`
@@ -205,6 +206,8 @@ func (cli *CLI) Run(ctx context.Context, args []string) error {
 		return app.Deploy(ctx, cli.Deploy.DeployOption())
 	case "schedule":
 		return app.Deploy(ctx, cli.Schedule.DeployOption())
+	case "rollback":
+		return app.Rollback(ctx, cli.Rollback)
 	case "delete":
 		return app.Delete(ctx, cli.Delete)
 	case "render":

--- a/cli.go
+++ b/cli.go
@@ -30,6 +30,7 @@ type CLI struct {
 	Schedule ScheduleCommandOption `cmd:"" help:"Enable or disable schedule rules" json:"schedule,omitempty"`
 	Render   RenderOption          `cmd:"" help:"Render state machine definition" json:"render,omitempty"`
 	Execute  ExecuteOption         `cmd:"" help:"Execute state machine" json:"execute,omitempty"`
+	Versions VersionsOption        `cmd:"" help:"Manage state machine versions" json:"versions,omitempty"`
 
 	kctx           *kong.Context
 	exitFunc       func(int)
@@ -210,6 +211,8 @@ func (cli *CLI) Run(ctx context.Context, args []string) error {
 		return app.Rollback(ctx, cli.Rollback)
 	case "delete":
 		return app.Delete(ctx, cli.Delete)
+	case "versions":
+		return app.Versions(ctx, cli.Versions)
 	case "render":
 		cli.Render.Writer = cli.stdout
 		return app.Render(ctx, cli.Render)

--- a/cli_test.go
+++ b/cli_test.go
@@ -172,6 +172,7 @@ func TestCLI__Parse(t *testing.T) {
 	)
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			LoggerSetup(t, "debug")
 			loc := dataloc.L(c.name)
 			for k, v := range c.envs {
 				t.Setenv(k, v)

--- a/config.go
+++ b/config.go
@@ -494,6 +494,12 @@ func (cfg *StateMachineConfig) Restrict() error {
 			Enabled: false,
 		}
 	}
+	if cfg.Value.Publish {
+		cfg.Value.Publish = false
+	}
+	if cfg.Value.VersionDescription != nil {
+		cfg.Value.VersionDescription = nil
+	}
 	return nil
 }
 

--- a/deploy.go
+++ b/deploy.go
@@ -14,7 +14,7 @@ type DeployCommandOption struct {
 	SkipDeployStateMachine bool   `name:"skip-deploy-state-machine" help:"Skip deploy state machine" json:"skip_deploy_state_machine,omitempty"`
 	VersionDescription     string `name:"version-description" help:"Version description" json:"version_description,omitempty"`
 	KeepVersions           int    `help:"Number of latest versions to keep. Older versions will be deleted. (Optional value: default 0)" default:"0" json:"keep_versions,omitempty"`
-	AliasName              string `name:"alias" help:"alias name for publish" defualt:"current" json:"alias,omitempty"`
+	AliasName              string `name:"alias" help:"alias name for publish" default:"current" json:"alias,omitempty"`
 }
 
 func (cmd *DeployCommandOption) DeployOption() DeployOption {
@@ -31,7 +31,7 @@ type ScheduleCommandOption struct {
 	DryRun    bool   `name:"dry-run" help:"Dry run" json:"dry_run,omitempty"`
 	Enabled   bool   `name:"enabled" help:"Enable schedule" xor:"schedule" required:"" json:"enabled,omitempty"`
 	Disabled  bool   `name:"disabled" help:"Disable schedule" xor:"schedule" required:"" json:"disabled,omitempty"`
-	AliasName string `name:"alias" help:"alias name for publish" defualt:"current" json:"alias,omitempty"`
+	AliasName string `name:"alias" help:"alias name for publish" default:"current" json:"alias,omitempty"`
 }
 
 func (cmd *ScheduleCommandOption) DeployOption() DeployOption {

--- a/deploy.go
+++ b/deploy.go
@@ -111,7 +111,7 @@ func (app *App) deployStateMachine(ctx context.Context, opt DeployOption) error 
 	}
 	log.Printf("[info] deploy state machine `%s`(at `%s`)\n", app.cfg.StateMachineName(), *output.UpdateDate)
 	if opt.KeepVersions > 0 {
-		if err := app.sfnSvc.PurgeStateMachineVersions(ctx, stateMachine, opt.KeepVersions); err != nil {
+		if err := app.sfnSvc.PurgeStateMachineVersions(ctx, newStateMachine, opt.KeepVersions); err != nil {
 			return fmt.Errorf("failed to delete older versions: %w", err)
 		}
 	}

--- a/encoding.go
+++ b/encoding.go
@@ -160,6 +160,12 @@ func deleteNilFromMap(v map[string]interface{}) map[string]interface{} {
 			}
 			continue
 		}
+		if b, ok := value.(bool); ok {
+			if !b {
+				delete(v, key)
+			}
+			continue
+		}
 		if m, ok := value.(map[string]interface{}); ok {
 			v[key] = deleteNilFromMap(m)
 			continue

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -52,7 +52,6 @@ logging_configuration:
   destinations:
     - cloudwatch_logs_log_group:
         log_group_arn: "arn:aws:logs:ap-northeast-1:123456789012:log-group:test:*"
-publish: false
 `
 	var obj stefunny.KeysToSnakeCase[sfn.CreateStateMachineInput]
 	err := yaml.Unmarshal([]byte(yamlStr), &obj)

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestYAML2JSON(t *testing.T) {
+	LoggerSetup(t, "debug")
 	yamlASL := LoadString(t, "testdata/hello_world.asl.yaml")
 	jsonASL := LoadString(t, "testdata/hello_world.asl.json")
 	bs, err := stefunny.YAML2JSON([]byte(yamlASL))
@@ -42,6 +43,7 @@ func TestJSON2Jsonnet(t *testing.T) {
 }
 
 func TestKeysToSnakeCase__CreateStateMachineInput(t *testing.T) {
+	LoggerSetup(t, "debug")
 	yamlStr := `
 name: "test"
 definition: "test.asl.json"

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/sebdah/goldie/v2 v2.5.3
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e
+	github.com/shogo82148/go-retry v1.2.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/term v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.24.7
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.7
+	github.com/aws/smithy-go v1.19.0
 	github.com/fatih/color v1.16.0
 	github.com/fujiwara/logutils v1.1.2
 	github.com/fujiwara/tfstate-lookup v1.1.6
@@ -64,7 +65,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.18.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.7 // indirect
-	github.com/aws/smithy-go v1.19.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/evanphx/json-patch v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -267,6 +267,8 @@ github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e/go.mod h1:Yow6lPLS
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
+github.com/shogo82148/go-retry v1.2.0 h1:A/LFdbZKJ+tsT1gF4OrzM4P10FGK7VUExpb07/U03aE=
+github.com/shogo82148/go-retry v1.2.0/go.mod h1:wttfgfwCMQvNqv4kOpqIvDDJeSmwU+AEIpUyG+5Ca6M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=

--- a/logger.go
+++ b/logger.go
@@ -9,7 +9,11 @@ import (
 	"github.com/fujiwara/logutils"
 )
 
-func LoggerSetup(w io.Writer, minLevel string) {
+func LoggerSetup(w io.Writer, minLevel string) func() {
+	beforeOutput := log.Writer()
+	cleanup := func() {
+		log.SetOutput(beforeOutput)
+	}
 	filter := &logutils.LevelFilter{
 		Levels:   []logutils.LogLevel{"debug", "info", "notice", "warn", "error"},
 		MinLevel: "info",
@@ -44,9 +48,10 @@ func LoggerSetup(w io.Writer, minLevel string) {
 			}),
 		)
 		log.Println("[debug] Setting log level to", minLevel)
-		return
+		return cleanup
 	}
 	log.SetOutput(filter)
+	return cleanup
 }
 
 type writerFunc func([]byte) (int, error)

--- a/mock_test.go
+++ b/mock_test.go
@@ -630,22 +630,13 @@ func (m *mockSFnService) RollbackStateMachine(ctx context.Context, stateMachine 
 	return args.Error(0)
 }
 
-func (m *mockSFnService) WaitExecution(ctx context.Context, executionArn string) (*stefunny.WaitExecutionOutput, error) {
-	args := m.Called(ctx, executionArn)
-	output := args.Get(0)
-	err := args.Error(1)
-	if err == nil {
-		if o, ok := output.(*stefunny.WaitExecutionOutput); ok {
-			return o, nil
-		}
-		require.FailNow(m.t, "mock data is not *stefunny.WaitExecutionOutput")
-		return nil, errors.New("mock data is not *stefunny.WaitExecutionOutput")
+func (m *mockSFnService) StartExecution(ctx context.Context, stateMachine *stefunny.StateMachine, params *stefunny.StartExecutionInput, optFns ...func(*sfn.Options)) (*stefunny.StartExecutionOutput, error) {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, stateMachine, params, optFns)
+	} else {
+		args = m.Called(ctx, stateMachine, params)
 	}
-	return nil, err
-}
-
-func (m *mockSFnService) StartExecution(ctx context.Context, stateMachine *stefunny.StateMachine, executionName, input string) (*stefunny.StartExecutionOutput, error) {
-	args := m.Called(ctx, stateMachine, executionName, input)
 	output := args.Get(0)
 	err := args.Error(1)
 	if err == nil {
@@ -654,20 +645,6 @@ func (m *mockSFnService) StartExecution(ctx context.Context, stateMachine *stefu
 		}
 		require.FailNow(m.t, "mock data is not *stefunny.StartExecutionOutput")
 		return nil, errors.New("mock data is not *stefunny.StartExecutionOutput")
-	}
-	return nil, err
-}
-
-func (m *mockSFnService) StartSyncExecution(ctx context.Context, stateMachine *stefunny.StateMachine, executionName, input string) (*sfn.StartSyncExecutionOutput, error) {
-	args := m.Called(ctx, stateMachine, executionName, input)
-	output := args.Get(0)
-	err := args.Error(1)
-	if err == nil {
-		if o, ok := output.(*sfn.StartSyncExecutionOutput); ok {
-			return o, nil
-		}
-		require.FailNow(m.t, "mock data is not *sfn.StartSyncExecutionOutput")
-		return nil, errors.New("mock data is not *sfn.StartSyncExecutionOutput")
 	}
 	return nil, err
 }

--- a/mock_test.go
+++ b/mock_test.go
@@ -254,6 +254,120 @@ func (m *mockSFnClient) GetExecutionHistory(ctx context.Context, params *sfn.Get
 	return nil, err
 }
 
+func (m *mockSFnClient) CreateStateMachineAlias(ctx context.Context, params *sfn.CreateStateMachineAliasInput, optFns ...func(*sfn.Options)) (*sfn.CreateStateMachineAliasOutput, error) {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, params, optFns)
+	} else {
+		args = m.Called(ctx, params)
+	}
+	output := args.Get(0)
+	err := args.Error(1)
+	if err == nil {
+		if o, ok := output.(*sfn.CreateStateMachineAliasOutput); ok {
+			return o, nil
+		}
+		require.FailNow(m.t, "mock data is not *sfn.CreateStateMachineAliasOutput")
+		return nil, errors.New("mock data is not *sfn.CreateStateMachineAliasOutput")
+	}
+	return nil, err
+}
+
+func (m *mockSFnClient) DescribeStateMachineAlias(ctx context.Context, params *sfn.DescribeStateMachineAliasInput, optFns ...func(*sfn.Options)) (*sfn.DescribeStateMachineAliasOutput, error) {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, params, optFns)
+	} else {
+		args = m.Called(ctx, params)
+	}
+	output := args.Get(0)
+	err := args.Error(1)
+	if err == nil {
+		if o, ok := output.(*sfn.DescribeStateMachineAliasOutput); ok {
+			return o, nil
+		}
+		require.FailNow(m.t, "mock data is not *sfn.DescribeStateMachineAliasOutput")
+		return nil, errors.New("mock data is not *sfn.DescribeStateMachineAliasOutput")
+	}
+	return nil, err
+}
+
+func (m *mockSFnClient) ListStateMachineVersions(ctx context.Context, params *sfn.ListStateMachineVersionsInput, optFns ...func(*sfn.Options)) (*sfn.ListStateMachineVersionsOutput, error) {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, params, optFns)
+	} else {
+		args = m.Called(ctx, params)
+	}
+	output := args.Get(0)
+	err := args.Error(1)
+	if err == nil {
+		if o, ok := output.(*sfn.ListStateMachineVersionsOutput); ok {
+			return o, nil
+		}
+		require.FailNow(m.t, "mock data is not *sfn.ListStateMachineVersionsOutput")
+		return nil, errors.New("mock data is not *sfn.ListStateMachineVersionsOutput")
+	}
+	return nil, err
+}
+
+func (m *mockSFnClient) UpdateStateMachineAlias(ctx context.Context, params *sfn.UpdateStateMachineAliasInput, optFns ...func(*sfn.Options)) (*sfn.UpdateStateMachineAliasOutput, error) {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, params, optFns)
+	} else {
+		args = m.Called(ctx, params)
+	}
+	output := args.Get(0)
+	err := args.Error(1)
+	if err == nil {
+		if o, ok := output.(*sfn.UpdateStateMachineAliasOutput); ok {
+			return o, nil
+		}
+		require.FailNow(m.t, "mock data is not *sfn.UpdateStateMachineAliasOutput")
+		return nil, errors.New("mock data is not *sfn.UpdateStateMachineAliasOutput")
+	}
+	return nil, err
+}
+
+func (m *mockSFnClient) PublishStateMachineVersion(ctx context.Context, params *sfn.PublishStateMachineVersionInput, optFns ...func(*sfn.Options)) (*sfn.PublishStateMachineVersionOutput, error) {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, params, optFns)
+	} else {
+		args = m.Called(ctx, params)
+	}
+	output := args.Get(0)
+	err := args.Error(1)
+	if err == nil {
+		if o, ok := output.(*sfn.PublishStateMachineVersionOutput); ok {
+			return o, nil
+		}
+		require.FailNow(m.t, "mock data is not *sfn.PublishStateMachineVersionOutput")
+		return nil, errors.New("mock data is not *sfn.PublishStateMachineVersionOutput")
+	}
+	return nil, err
+}
+
+func (m *mockSFnClient) DeleteStateMachineVersion(ctx context.Context, params *sfn.DeleteStateMachineVersionInput, optFns ...func(*sfn.Options)) (*sfn.DeleteStateMachineVersionOutput, error) {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, params, optFns)
+	} else {
+		args = m.Called(ctx, params)
+	}
+	output := args.Get(0)
+	err := args.Error(1)
+	if err == nil {
+		if o, ok := output.(*sfn.DeleteStateMachineVersionOutput); ok {
+			return o, nil
+		}
+		require.FailNow(m.t, "mock data is not *sfn.DeleteStateMachineVersionOutput")
+		return nil, errors.New("mock data is not *sfn.DeleteStateMachineVersionOutput")
+	}
+	return nil, err
+}
+
 func (m *mockEventBridgeClient) TagResource(ctx context.Context, params *eventbridge.TagResourceInput, optFns ...func(*eventbridge.Options)) (*eventbridge.TagResourceOutput, error) {
 	var args mock.Arguments
 	if len(optFns) > 0 {

--- a/mock_test.go
+++ b/mock_test.go
@@ -568,6 +568,16 @@ func (m *mockSFnService) DeleteStateMachine(ctx context.Context, stateMachine *s
 	return args.Error(0)
 }
 
+func (m *mockSFnService) RollbackStateMachine(ctx context.Context, stateMachine *stefunny.StateMachine, keepVersion bool, dryRun bool, optFns ...func(*sfn.Options)) error {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, stateMachine, keepVersion, dryRun, optFns)
+	} else {
+		args = m.Called(ctx, stateMachine, keepVersion, dryRun)
+	}
+	return args.Error(0)
+}
+
 func (m *mockSFnService) WaitExecution(ctx context.Context, executionArn string) (*stefunny.WaitExecutionOutput, error) {
 	args := m.Called(ctx, executionArn)
 	output := args.Get(0)

--- a/mock_test.go
+++ b/mock_test.go
@@ -529,6 +529,10 @@ func NewMockSFnService(t *testing.T) *mockSFnService {
 	return m
 }
 
+func (m *mockSFnService) SetAliasName(name string) {
+	m.Called(name)
+}
+
 func (m *mockSFnService) GetStateMachineArn(ctx context.Context, name string, optFns ...func(*sfn.Options)) (string, error) {
 	var args mock.Arguments
 	if len(optFns) > 0 {

--- a/mock_test.go
+++ b/mock_test.go
@@ -292,6 +292,25 @@ func (m *mockSFnClient) DescribeStateMachineAlias(ctx context.Context, params *s
 	return nil, err
 }
 
+func (m *mockSFnClient) ListStateMachineAliases(ctx context.Context, params *sfn.ListStateMachineAliasesInput, optFns ...func(*sfn.Options)) (*sfn.ListStateMachineAliasesOutput, error) {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, params, optFns)
+	} else {
+		args = m.Called(ctx, params)
+	}
+	output := args.Get(0)
+	err := args.Error(1)
+	if err == nil {
+		if o, ok := output.(*sfn.ListStateMachineAliasesOutput); ok {
+			return o, nil
+		}
+		require.FailNow(m.t, "mock data is not *sfn.ListStateMachineAliasesOutput")
+		return nil, errors.New("mock data is not *sfn.ListStateMachineAliasesOutput")
+	}
+	return nil, err
+}
+
 func (m *mockSFnClient) ListStateMachineVersions(ctx context.Context, params *sfn.ListStateMachineVersionsInput, optFns ...func(*sfn.Options)) (*sfn.ListStateMachineVersionsOutput, error) {
 	var args mock.Arguments
 	if len(optFns) > 0 {
@@ -535,6 +554,35 @@ func (m *mockSFnService) DescribeStateMachine(ctx context.Context, name string, 
 		}
 		require.FailNow(m.t, "mock data is not *stefunny.StateMachine")
 		return nil, errors.New("mock data is not *stefunny.StateMachine")
+	}
+	return nil, err
+}
+
+func (m *mockSFnService) PurgeStateMachineVersions(ctx context.Context, stateMachine *stefunny.StateMachine, keepVersions int, optFns ...func(*sfn.Options)) error {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, stateMachine, keepVersions, optFns)
+	} else {
+		args = m.Called(ctx, stateMachine, keepVersions)
+	}
+	return args.Error(0)
+}
+
+func (m *mockSFnService) ListStateMachineVersions(ctx context.Context, stateMachine *stefunny.StateMachine, optFns ...func(*sfn.Options)) (*stefunny.ListStateMachineVersionsOutput, error) {
+	var args mock.Arguments
+	if len(optFns) > 0 {
+		args = m.Called(ctx, stateMachine, optFns)
+	} else {
+		args = m.Called(ctx, stateMachine)
+	}
+	output := args.Get(0)
+	err := args.Error(1)
+	if err == nil {
+		if o, ok := output.(*stefunny.ListStateMachineVersionsOutput); ok {
+			return o, nil
+		}
+		require.FailNow(m.t, "mock data is not []stefunny.StateMachineVersion")
+		return nil, errors.New("mock data is not []stefunny.StateMachineVersion")
 	}
 	return nil, err
 }

--- a/mock_test.go
+++ b/mock_test.go
@@ -330,25 +330,6 @@ func (m *mockSFnClient) UpdateStateMachineAlias(ctx context.Context, params *sfn
 	return nil, err
 }
 
-func (m *mockSFnClient) PublishStateMachineVersion(ctx context.Context, params *sfn.PublishStateMachineVersionInput, optFns ...func(*sfn.Options)) (*sfn.PublishStateMachineVersionOutput, error) {
-	var args mock.Arguments
-	if len(optFns) > 0 {
-		args = m.Called(ctx, params, optFns)
-	} else {
-		args = m.Called(ctx, params)
-	}
-	output := args.Get(0)
-	err := args.Error(1)
-	if err == nil {
-		if o, ok := output.(*sfn.PublishStateMachineVersionOutput); ok {
-			return o, nil
-		}
-		require.FailNow(m.t, "mock data is not *sfn.PublishStateMachineVersionOutput")
-		return nil, errors.New("mock data is not *sfn.PublishStateMachineVersionOutput")
-	}
-	return nil, err
-}
-
 func (m *mockSFnClient) DeleteStateMachineVersion(ctx context.Context, params *sfn.DeleteStateMachineVersionInput, optFns ...func(*sfn.Options)) (*sfn.DeleteStateMachineVersionOutput, error) {
 	var args mock.Arguments
 	if len(optFns) > 0 {

--- a/rollback.go
+++ b/rollback.go
@@ -8,8 +8,9 @@ import (
 )
 
 type RollbackOption struct {
-	DryRun      bool `name:"dry-run" help:"Dry run" json:"dry_run,omitempty"`
-	KeepVersion bool `name:"keep-version" help:"Keep current version, no delete" json:"keep_version,omitempty"`
+	DryRun      bool   `name:"dry-run" help:"Dry run" json:"dry_run,omitempty"`
+	KeepVersion bool   `name:"keep-version" help:"Keep current version, no delete" json:"keep_version,omitempty"`
+	AliasName   string `name:"alias" help:"alias name for rollback target" defualt:"current" json:"alias,omitempty"`
 }
 
 func (opt RollbackOption) DryRunString() string {
@@ -20,6 +21,9 @@ func (opt RollbackOption) DryRunString() string {
 }
 
 func (app *App) Rollback(ctx context.Context, opt RollbackOption) error {
+	if opt.AliasName != "" {
+		app.sfnSvc.SetAliasName(opt.AliasName)
+	}
 	stateMachine, err := app.sfnSvc.DescribeStateMachine(ctx, app.cfg.StateMachineName())
 	if err != nil {
 		if errors.Is(err, ErrStateMachineDoesNotExist) {

--- a/rollback.go
+++ b/rollback.go
@@ -10,7 +10,7 @@ import (
 type RollbackOption struct {
 	DryRun      bool   `name:"dry-run" help:"Dry run" json:"dry_run,omitempty"`
 	KeepVersion bool   `name:"keep-version" help:"Keep current version, no delete" json:"keep_version,omitempty"`
-	AliasName   string `name:"alias" help:"alias name for rollback target" defualt:"current" json:"alias,omitempty"`
+	AliasName   string `name:"alias" help:"alias name for rollback target" default:"current" json:"alias,omitempty"`
 }
 
 func (opt RollbackOption) DryRunString() string {

--- a/rollback.go
+++ b/rollback.go
@@ -1,0 +1,37 @@
+package stefunny
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+)
+
+type RollbackOption struct {
+	DryRun      bool `name:"dry-run" help:"Dry run" json:"dry_run,omitempty"`
+	KeepVersion bool `name:"keep-version" help:"Keep current version, no delete" json:"keep_version,omitempty"`
+}
+
+func (opt RollbackOption) DryRunString() string {
+	if opt.DryRun {
+		return dryRunStr
+	}
+	return ""
+}
+
+func (app *App) Rollback(ctx context.Context, opt RollbackOption) error {
+	stateMachine, err := app.sfnSvc.DescribeStateMachine(ctx, app.cfg.StateMachineName())
+	if err != nil {
+		if errors.Is(err, ErrStateMachineDoesNotExist) {
+			return fmt.Errorf("state machine `%s` is not found", app.cfg.StateMachineName())
+		}
+		return fmt.Errorf("failed to describe current state machine status: %w", err)
+	}
+
+	log.Println("[info] Starting rollback", *stateMachine.StateMachineArn, opt.DryRunString())
+	if err := app.sfnSvc.RollbackStateMachine(ctx, stateMachine, opt.KeepVersion, opt.DryRun); err != nil {
+		return err
+	}
+	log.Println("[info] finish rollback", *stateMachine.StateMachineArn, opt.DryRunString())
+	return nil
+}

--- a/testdata/cli/delete_help/data.golden.json
+++ b/testdata/cli/delete_help/data.golden.json
@@ -6,5 +6,6 @@
   "rollback": {},
   "schedule": {},
   "render": {},
-  "execute": {}
+  "execute": {},
+  "versions": {}
 }

--- a/testdata/cli/delete_help/data.golden.json
+++ b/testdata/cli/delete_help/data.golden.json
@@ -3,6 +3,7 @@
   "init": {},
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {}

--- a/testdata/cli/delete_with_dry-run/data.golden.json
+++ b/testdata/cli/delete_with_dry-run/data.golden.json
@@ -15,5 +15,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/delete_with_dry-run/data.golden.json
+++ b/testdata/cli/delete_with_dry-run/data.golden.json
@@ -9,9 +9,15 @@
   "delete": {
     "dry_run": true
   },
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "-"

--- a/testdata/cli/delete_with_dry-run/data.golden.json
+++ b/testdata/cli/delete_with_dry-run/data.golden.json
@@ -10,6 +10,7 @@
     "dry_run": true
   },
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/delete_with_log-level/data.golden.json
+++ b/testdata/cli/delete_with_log-level/data.golden.json
@@ -7,9 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "-"

--- a/testdata/cli/delete_with_log-level/data.golden.json
+++ b/testdata/cli/delete_with_log-level/data.golden.json
@@ -13,5 +13,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/delete_with_log-level/data.golden.json
+++ b/testdata/cli/delete_with_log-level/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/deploy_dry_run/data.golden.json
+++ b/testdata/cli/deploy_dry_run/data.golden.json
@@ -10,6 +10,7 @@
   "deploy": {
     "dry_run": true
   },
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/deploy_dry_run/data.golden.json
+++ b/testdata/cli/deploy_dry_run/data.golden.json
@@ -15,5 +15,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/deploy_dry_run/data.golden.json
+++ b/testdata/cli/deploy_dry_run/data.golden.json
@@ -8,10 +8,15 @@
   },
   "delete": {},
   "deploy": {
-    "dry_run": true
+    "dry_run": true,
+    "alias": "current"
   },
-  "rollback": {},
-  "schedule": {},
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "-"

--- a/testdata/cli/deploy_help/console.golden.txt
+++ b/testdata/cli/deploy_help/console.golden.txt
@@ -16,3 +16,5 @@ Flags:
       --dry-run                 Dry run
       --skip-deploy-state-machine
                                 Skip deploy state machine
+      --version-description=STRING
+                                Version description

--- a/testdata/cli/deploy_help/console.golden.txt
+++ b/testdata/cli/deploy_help/console.golden.txt
@@ -18,3 +18,7 @@ Flags:
                                 Skip deploy state machine
       --version-description=STRING
                                 Version description
+      --keep-versions=0         Number of latest versions to keep. Older
+                                versions will be deleted. (Optional value:
+                                default 0)
+      --alias=STRING            alias name for publish

--- a/testdata/cli/deploy_help/console.golden.txt
+++ b/testdata/cli/deploy_help/console.golden.txt
@@ -21,4 +21,4 @@ Flags:
       --keep-versions=0         Number of latest versions to keep. Older
                                 versions will be deleted. (Optional value:
                                 default 0)
-      --alias=STRING            alias name for publish
+      --alias="current"         alias name for publish

--- a/testdata/cli/deploy_help/data.golden.json
+++ b/testdata/cli/deploy_help/data.golden.json
@@ -6,5 +6,6 @@
   "rollback": {},
   "schedule": {},
   "render": {},
-  "execute": {}
+  "execute": {},
+  "versions": {}
 }

--- a/testdata/cli/deploy_help/data.golden.json
+++ b/testdata/cli/deploy_help/data.golden.json
@@ -3,6 +3,7 @@
   "init": {},
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {}

--- a/testdata/cli/deploy_with_region/data.golden.json
+++ b/testdata/cli/deploy_with_region/data.golden.json
@@ -7,9 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "-"

--- a/testdata/cli/deploy_with_region/data.golden.json
+++ b/testdata/cli/deploy_with_region/data.golden.json
@@ -13,5 +13,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/deploy_with_region/data.golden.json
+++ b/testdata/cli/deploy_with_region/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/execute/data.golden.json
+++ b/testdata/cli/execute/data.golden.json
@@ -7,9 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "-"

--- a/testdata/cli/execute/data.golden.json
+++ b/testdata/cli/execute/data.golden.json
@@ -13,5 +13,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/execute/data.golden.json
+++ b/testdata/cli/execute/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/execute_help/console.golden.txt
+++ b/testdata/cli/execute_help/console.golden.txt
@@ -17,3 +17,4 @@ Flags:
       --name=""                 execution name
       --async                   start execution and return immediately
       --dump-history            dump execution history
+      --qualifier=QUALIFIER     state machine version qualifier

--- a/testdata/cli/execute_help/data.golden.json
+++ b/testdata/cli/execute_help/data.golden.json
@@ -6,5 +6,6 @@
   "rollback": {},
   "schedule": {},
   "render": {},
-  "execute": {}
+  "execute": {},
+  "versions": {}
 }

--- a/testdata/cli/execute_help/data.golden.json
+++ b/testdata/cli/execute_help/data.golden.json
@@ -3,6 +3,7 @@
   "init": {},
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {}

--- a/testdata/cli/execute_with_input/data.golden.json
+++ b/testdata/cli/execute_with_input/data.golden.json
@@ -13,5 +13,9 @@
   "render": {},
   "execute": {
     "input": "testdata/input.json"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/execute_with_input/data.golden.json
+++ b/testdata/cli/execute_with_input/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/execute_with_input/data.golden.json
+++ b/testdata/cli/execute_with_input/data.golden.json
@@ -7,9 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "testdata/input.json"

--- a/testdata/cli/execute_with_stdin/data.golden.json
+++ b/testdata/cli/execute_with_stdin/data.golden.json
@@ -7,9 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "-"

--- a/testdata/cli/execute_with_stdin/data.golden.json
+++ b/testdata/cli/execute_with_stdin/data.golden.json
@@ -13,5 +13,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/execute_with_stdin/data.golden.json
+++ b/testdata/cli/execute_with_stdin/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/help/console.golden.txt
+++ b/testdata/cli/help/console.golden.txt
@@ -38,4 +38,7 @@ Commands:
   execute
     Execute state machine
 
+  versions
+    Manage state machine versions
+
 Run "stefunny <command> --help" for more information on a command.

--- a/testdata/cli/help/console.golden.txt
+++ b/testdata/cli/help/console.golden.txt
@@ -26,6 +26,9 @@ Commands:
   deploy
     Deploy state machine and schedule rules
 
+  rollback
+    Rollback state machine
+
   schedule --enabled --disabled
     Enable or disable schedule rules
 

--- a/testdata/cli/help/data.golden.json
+++ b/testdata/cli/help/data.golden.json
@@ -6,5 +6,6 @@
   "rollback": {},
   "schedule": {},
   "render": {},
-  "execute": {}
+  "execute": {},
+  "versions": {}
 }

--- a/testdata/cli/help/data.golden.json
+++ b/testdata/cli/help/data.golden.json
@@ -3,6 +3,7 @@
   "init": {},
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {}

--- a/testdata/cli/init/data.golden.json
+++ b/testdata/cli/init/data.golden.json
@@ -9,6 +9,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/init/data.golden.json
+++ b/testdata/cli/init/data.golden.json
@@ -8,9 +8,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "-"

--- a/testdata/cli/init/data.golden.json
+++ b/testdata/cli/init/data.golden.json
@@ -14,5 +14,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/init_help/data.golden.json
+++ b/testdata/cli/init_help/data.golden.json
@@ -6,5 +6,6 @@
   "rollback": {},
   "schedule": {},
   "render": {},
-  "execute": {}
+  "execute": {},
+  "versions": {}
 }

--- a/testdata/cli/init_help/data.golden.json
+++ b/testdata/cli/init_help/data.golden.json
@@ -3,6 +3,7 @@
   "init": {},
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {}

--- a/testdata/cli/init_with_config/data.golden.json
+++ b/testdata/cli/init_with_config/data.golden.json
@@ -9,6 +9,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/init_with_config/data.golden.json
+++ b/testdata/cli/init_with_config/data.golden.json
@@ -8,9 +8,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "-"

--- a/testdata/cli/init_with_config/data.golden.json
+++ b/testdata/cli/init_with_config/data.golden.json
@@ -14,5 +14,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/no_args/console.golden.txt
+++ b/testdata/cli/no_args/console.golden.txt
@@ -26,6 +26,9 @@ Commands:
   deploy
     Deploy state machine and schedule rules
 
+  rollback
+    Rollback state machine
+
   schedule --enabled --disabled
     Enable or disable schedule rules
 
@@ -37,4 +40,4 @@ Commands:
 
 Run "stefunny <command> --help" for more information on a command.
 
-stefunny: error: expected one of "version",  "init",  "delete",  "deploy",  "schedule",  ...
+stefunny: error: expected one of "version",  "init",  "delete",  "deploy",  "rollback",  ...

--- a/testdata/cli/no_args/console.golden.txt
+++ b/testdata/cli/no_args/console.golden.txt
@@ -38,6 +38,9 @@ Commands:
   execute
     Execute state machine
 
+  versions
+    Manage state machine versions
+
 Run "stefunny <command> --help" for more information on a command.
 
 stefunny: error: expected one of "version",  "init",  "delete",  "deploy",  "rollback",  ...

--- a/testdata/cli/no_args/data.golden.json
+++ b/testdata/cli/no_args/data.golden.json
@@ -7,9 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "-"

--- a/testdata/cli/no_args/data.golden.json
+++ b/testdata/cli/no_args/data.golden.json
@@ -13,5 +13,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/no_args/data.golden.json
+++ b/testdata/cli/no_args/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/render/data.golden.json
+++ b/testdata/cli/render/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {
     "targets": [

--- a/testdata/cli/render/data.golden.json
+++ b/testdata/cli/render/data.golden.json
@@ -7,9 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {
     "targets": [
       "config"

--- a/testdata/cli/render/data.golden.json
+++ b/testdata/cli/render/data.golden.json
@@ -17,5 +17,9 @@
   },
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/render_help/data.golden.json
+++ b/testdata/cli/render_help/data.golden.json
@@ -6,5 +6,6 @@
   "rollback": {},
   "schedule": {},
   "render": {},
-  "execute": {}
+  "execute": {},
+  "versions": {}
 }

--- a/testdata/cli/render_help/data.golden.json
+++ b/testdata/cli/render_help/data.golden.json
@@ -3,6 +3,7 @@
   "init": {},
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {}

--- a/testdata/cli/render_invalid_format/data.golden.json
+++ b/testdata/cli/render_invalid_format/data.golden.json
@@ -15,5 +15,9 @@
   },
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/render_invalid_format/data.golden.json
+++ b/testdata/cli/render_invalid_format/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {
     "format": "invalid"

--- a/testdata/cli/render_invalid_format/data.golden.json
+++ b/testdata/cli/render_invalid_format/data.golden.json
@@ -7,9 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {
     "format": "invalid"
   },

--- a/testdata/cli/render_with_format/data.golden.json
+++ b/testdata/cli/render_with_format/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {
     "targets": [

--- a/testdata/cli/render_with_format/data.golden.json
+++ b/testdata/cli/render_with_format/data.golden.json
@@ -7,9 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {
     "targets": [
       "def"

--- a/testdata/cli/render_with_format/data.golden.json
+++ b/testdata/cli/render_with_format/data.golden.json
@@ -18,5 +18,9 @@
   },
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/schedule_disable/data.golden.json
+++ b/testdata/cli/schedule_disable/data.golden.json
@@ -7,10 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
   "schedule": {
-    "disabled": true
+    "disabled": true,
+    "alias": "current"
   },
   "render": {},
   "execute": {

--- a/testdata/cli/schedule_disable/data.golden.json
+++ b/testdata/cli/schedule_disable/data.golden.json
@@ -15,5 +15,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/schedule_disable/data.golden.json
+++ b/testdata/cli/schedule_disable/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {
     "disabled": true
   },

--- a/testdata/cli/schedule_dry_run/data.golden.json
+++ b/testdata/cli/schedule_dry_run/data.golden.json
@@ -16,5 +16,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/schedule_dry_run/data.golden.json
+++ b/testdata/cli/schedule_dry_run/data.golden.json
@@ -7,11 +7,16 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
   "schedule": {
     "dry_run": true,
-    "enabled": true
+    "enabled": true,
+    "alias": "current"
   },
   "render": {},
   "execute": {

--- a/testdata/cli/schedule_dry_run/data.golden.json
+++ b/testdata/cli/schedule_dry_run/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {
     "dry_run": true,
     "enabled": true

--- a/testdata/cli/schedule_enable/data.golden.json
+++ b/testdata/cli/schedule_enable/data.golden.json
@@ -15,5 +15,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/schedule_enable/data.golden.json
+++ b/testdata/cli/schedule_enable/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {
     "enabled": true
   },

--- a/testdata/cli/schedule_enable/data.golden.json
+++ b/testdata/cli/schedule_enable/data.golden.json
@@ -7,10 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
   "schedule": {
-    "enabled": true
+    "enabled": true,
+    "alias": "current"
   },
   "render": {},
   "execute": {

--- a/testdata/cli/schedule_help/console.golden.txt
+++ b/testdata/cli/schedule_help/console.golden.txt
@@ -16,3 +16,4 @@ Flags:
       --dry-run                 Dry run
       --enabled                 Enable schedule
       --disabled                Disable schedule
+      --alias=STRING            alias name for publish

--- a/testdata/cli/schedule_help/console.golden.txt
+++ b/testdata/cli/schedule_help/console.golden.txt
@@ -16,4 +16,4 @@ Flags:
       --dry-run                 Dry run
       --enabled                 Enable schedule
       --disabled                Disable schedule
-      --alias=STRING            alias name for publish
+      --alias="current"         alias name for publish

--- a/testdata/cli/schedule_help/data.golden.json
+++ b/testdata/cli/schedule_help/data.golden.json
@@ -6,5 +6,6 @@
   "rollback": {},
   "schedule": {},
   "render": {},
-  "execute": {}
+  "execute": {},
+  "versions": {}
 }

--- a/testdata/cli/schedule_help/data.golden.json
+++ b/testdata/cli/schedule_help/data.golden.json
@@ -3,6 +3,7 @@
   "init": {},
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {}

--- a/testdata/cli/schedule_invalid/console.golden.txt
+++ b/testdata/cli/schedule_invalid/console.golden.txt
@@ -16,5 +16,6 @@ Flags:
       --dry-run                 Dry run
       --enabled                 Enable schedule
       --disabled                Disable schedule
+      --alias=STRING            alias name for publish
 
 stefunny: error: --enabled and --disabled can't be used together

--- a/testdata/cli/schedule_invalid/console.golden.txt
+++ b/testdata/cli/schedule_invalid/console.golden.txt
@@ -16,6 +16,6 @@ Flags:
       --dry-run                 Dry run
       --enabled                 Enable schedule
       --disabled                Disable schedule
-      --alias=STRING            alias name for publish
+      --alias="current"         alias name for publish
 
 stefunny: error: --enabled and --disabled can't be used together

--- a/testdata/cli/schedule_invalid/data.golden.json
+++ b/testdata/cli/schedule_invalid/data.golden.json
@@ -16,5 +16,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/schedule_invalid/data.golden.json
+++ b/testdata/cli/schedule_invalid/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {
     "enabled": true,
     "disabled": true

--- a/testdata/cli/schedule_invalid/data.golden.json
+++ b/testdata/cli/schedule_invalid/data.golden.json
@@ -7,11 +7,16 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
   "schedule": {
     "enabled": true,
-    "disabled": true
+    "disabled": true,
+    "alias": "current"
   },
   "render": {},
   "execute": {

--- a/testdata/cli/schedule_no_flag/console.golden.txt
+++ b/testdata/cli/schedule_no_flag/console.golden.txt
@@ -16,6 +16,6 @@ Flags:
       --dry-run                 Dry run
       --enabled                 Enable schedule
       --disabled                Disable schedule
-      --alias=STRING            alias name for publish
+      --alias="current"         alias name for publish
 
 stefunny: error: missing flags: --enabled or --disabled

--- a/testdata/cli/schedule_no_flag/console.golden.txt
+++ b/testdata/cli/schedule_no_flag/console.golden.txt
@@ -16,5 +16,6 @@ Flags:
       --dry-run                 Dry run
       --enabled                 Enable schedule
       --disabled                Disable schedule
+      --alias=STRING            alias name for publish
 
 stefunny: error: missing flags: --enabled or --disabled

--- a/testdata/cli/schedule_no_flag/data.golden.json
+++ b/testdata/cli/schedule_no_flag/data.golden.json
@@ -7,9 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "-"

--- a/testdata/cli/schedule_no_flag/data.golden.json
+++ b/testdata/cli/schedule_no_flag/data.golden.json
@@ -13,5 +13,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/schedule_no_flag/data.golden.json
+++ b/testdata/cli/schedule_no_flag/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/unknown_command/console.golden.txt
+++ b/testdata/cli/unknown_command/console.golden.txt
@@ -38,6 +38,9 @@ Commands:
   execute
     Execute state machine
 
+  versions
+    Manage state machine versions
+
 Run "stefunny <command> --help" for more information on a command.
 
 stefunny: error: unexpected argument unknown

--- a/testdata/cli/unknown_command/console.golden.txt
+++ b/testdata/cli/unknown_command/console.golden.txt
@@ -26,6 +26,9 @@ Commands:
   deploy
     Deploy state machine and schedule rules
 
+  rollback
+    Rollback state machine
+
   schedule --enabled --disabled
     Enable or disable schedule rules
 

--- a/testdata/cli/unknown_command/data.golden.json
+++ b/testdata/cli/unknown_command/data.golden.json
@@ -6,5 +6,6 @@
   "rollback": {},
   "schedule": {},
   "render": {},
-  "execute": {}
+  "execute": {},
+  "versions": {}
 }

--- a/testdata/cli/unknown_command/data.golden.json
+++ b/testdata/cli/unknown_command/data.golden.json
@@ -3,6 +3,7 @@
   "init": {},
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {}

--- a/testdata/cli/version/data.golden.json
+++ b/testdata/cli/version/data.golden.json
@@ -7,9 +7,15 @@
     "definition_file_path": "definition.asl.json"
   },
   "delete": {},
-  "deploy": {},
-  "rollback": {},
-  "schedule": {},
+  "deploy": {
+    "alias": "current"
+  },
+  "rollback": {
+    "alias": "current"
+  },
+  "schedule": {
+    "alias": "current"
+  },
   "render": {},
   "execute": {
     "input": "-"

--- a/testdata/cli/version/data.golden.json
+++ b/testdata/cli/version/data.golden.json
@@ -13,5 +13,9 @@
   "render": {},
   "execute": {
     "input": "-"
+  },
+  "versions": {
+    "format": "table",
+    "keep_versions": 5
   }
 }

--- a/testdata/cli/version/data.golden.json
+++ b/testdata/cli/version/data.golden.json
@@ -8,6 +8,7 @@
   },
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {

--- a/testdata/cli/version_help/data.golden.json
+++ b/testdata/cli/version_help/data.golden.json
@@ -6,5 +6,6 @@
   "rollback": {},
   "schedule": {},
   "render": {},
-  "execute": {}
+  "execute": {},
+  "versions": {}
 }

--- a/testdata/cli/version_help/data.golden.json
+++ b/testdata/cli/version_help/data.golden.json
@@ -3,6 +3,7 @@
   "init": {},
   "delete": {},
   "deploy": {},
+  "rollback": {},
   "schedule": {},
   "render": {},
   "execute": {}

--- a/testdata/config/default_config.golden.json
+++ b/testdata/config/default_config.golden.json
@@ -11,15 +11,11 @@
           }
         }
       ],
-      "include_execution_data": false,
       "level": "ALL"
     },
     "name": "Hello",
-    "publish": false,
     "role_arn": "arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role",
-    "tracing_configuration": {
-      "enabled": false
-    },
+    "tracing_configuration": {},
     "type": "STANDARD"
   },
   "ConfigDir": "testdata"

--- a/testdata/config/jsonnet.golden.json
+++ b/testdata/config/jsonnet.golden.json
@@ -11,15 +11,11 @@
           }
         }
       ],
-      "include_execution_data": false,
       "level": "ALL"
     },
     "name": "Hello",
-    "publish": false,
     "role_arn": "arn:aws:iam::123456789012:role/StepFunctions-Hello-Role",
-    "tracing_configuration": {
-      "enabled": false
-    },
+    "tracing_configuration": {},
     "type": "STANDARD"
   },
   "ConfigDir": "testdata"

--- a/testdata/config/log_level_off.golden.json
+++ b/testdata/config/log_level_off.golden.json
@@ -4,15 +4,11 @@
   "state_machine": {
     "definition": "{\n   \"Comment\": \"A Hello World example of the Amazon States Language using Pass states\",\n   \"StartAt\": \"Hello\",\n   \"States\": {\n      \"Hello\": {\n         \"Next\": \"World\",\n         \"Type\": \"Pass\"\n      },\n      \"World\": {\n         \"End\": true,\n         \"Result\": \"World\",\n         \"Type\": \"Pass\"\n      }\n   }\n}",
     "logging_configuration": {
-      "include_execution_data": false,
       "level": "OFF"
     },
     "name": "Hello",
-    "publish": false,
     "role_arn": "arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role",
-    "tracing_configuration": {
-      "enabled": false
-    },
+    "tracing_configuration": {},
     "type": "STANDARD"
   },
   "ConfigDir": "testdata"

--- a/testdata/config/old_type_config_v0.5.0.golden.json
+++ b/testdata/config/old_type_config_v0.5.0.golden.json
@@ -11,11 +11,9 @@
           }
         }
       ],
-      "include_execution_data": false,
       "level": "ALL"
     },
     "name": "Hello",
-    "publish": false,
     "role_arn": "arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role",
     "tracing_configuration": {
       "enabled": true

--- a/testdata/config/tfstate_read.golden.json
+++ b/testdata/config/tfstate_read.golden.json
@@ -11,15 +11,11 @@
           }
         }
       ],
-      "include_execution_data": false,
       "level": "FATAL"
     },
     "name": "Hello",
-    "publish": false,
     "role_arn": "arn:aws:iam::000000000000:role/test",
-    "tracing_configuration": {
-      "enabled": false
-    },
+    "tracing_configuration": {},
     "type": "STANDARD"
   },
   "tfstate": [

--- a/testdata/config/yaml.golden.json
+++ b/testdata/config/yaml.golden.json
@@ -11,15 +11,11 @@
           }
         }
       ],
-      "include_execution_data": false,
       "level": "ALL"
     },
     "name": "Hello",
-    "publish": false,
     "role_arn": "arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role",
-    "tracing_configuration": {
-      "enabled": false
-    },
+    "tracing_configuration": {},
     "type": "STANDARD"
   },
   "ConfigDir": "testdata"

--- a/testdata/config/yaml_config_with_jsonnet_def.golden.json
+++ b/testdata/config/yaml_config_with_jsonnet_def.golden.json
@@ -11,15 +11,11 @@
           }
         }
       ],
-      "include_execution_data": false,
       "level": "FATAL"
     },
     "name": "Hello",
-    "publish": false,
     "role_arn": "arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role",
-    "tracing_configuration": {
-      "enabled": false
-    },
+    "tracing_configuration": {},
     "type": "STANDARD"
   },
   "ConfigDir": "testdata"

--- a/testdata/render/default.golden.txt
+++ b/testdata/render/default.golden.txt
@@ -6,13 +6,10 @@ state_machine:
         destinations:
             - cloudwatch_logs_log_group:
                 log_group_arn: arn:aws:logs:us-east-1:012345678901:log-group:/steps/hello
-        include_execution_data: false
         level: ALL
     name: Hello
-    publish: false
     role_arn: arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role
-    tracing_configuration:
-        enabled: false
+    tracing_configuration: {}
     type: STANDARD
 {
   "Comment": "A Hello World example of the Amazon States Language using Pass states",

--- a/testdata/render/env_config.golden.txt
+++ b/testdata/render/env_config.golden.txt
@@ -27,15 +27,11 @@
           },
         },
       ],
-      include_execution_data: false,
       level: 'FATAL',
     },
     name: 'Hello',
-    publish: false,
     role_arn: 'arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role',
-    tracing_configuration: {
-      enabled: false,
-    },
+    tracing_configuration: {},
     type: 'STANDARD',
   },
 }

--- a/testdata/render/full_def_to_jsonnet.golden.txt
+++ b/testdata/render/full_def_to_jsonnet.golden.txt
@@ -91,15 +91,11 @@
   state_machine: {
     definition: 'workflow1.asl.json',
     logging_configuration: {
-      include_execution_data: false,
       level: 'OFF',
     },
     name: 'Hello',
-    publish: false,
     role_arn: 'arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role',
-    tracing_configuration: {
-      enabled: false,
-    },
+    tracing_configuration: {},
     type: 'STANDARD',
   },
 }

--- a/testdata/render/jsonnet.golden.txt
+++ b/testdata/render/jsonnet.golden.txt
@@ -12,15 +12,11 @@
           },
         },
       ],
-      include_execution_data: false,
       level: 'ALL',
     },
     name: 'Hello',
-    publish: false,
     role_arn: 'arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role',
-    tracing_configuration: {
-      enabled: false,
-    },
+    tracing_configuration: {},
     type: 'STANDARD',
   },
 }

--- a/testdata/render/yaml.golden.txt
+++ b/testdata/render/yaml.golden.txt
@@ -6,13 +6,10 @@ state_machine:
         destinations:
             - cloudwatch_logs_log_group:
                 log_group_arn: arn:aws:logs:us-east-1:012345678901:log-group:/steps/hello
-        include_execution_data: false
         level: ALL
     name: Hello
-    publish: false
     role_arn: arn:aws:iam::012345678901:role/service-role/StepFunctions-Hello-role
-    tracing_configuration:
-        enabled: false
+    tracing_configuration: {}
     type: STANDARD
 |
     Comment: A Hello World example of the Amazon States Language using Pass states

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,7 +2,6 @@ package stefunny_test
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	gc "github.com/kayac/go-config"
@@ -19,12 +18,8 @@ func LoadString(t *testing.T, path string) string {
 }
 
 func LoggerSetup(t *testing.T, minLevel string) {
+	t.Helper()
 	var buf bytes.Buffer
-	stefunny.LoggerSetup(&buf, minLevel)
-	t.Cleanup(
-		func() {
-			stefunny.LoggerSetup(os.Stderr, minLevel)
-			t.Log(buf.String())
-		},
-	)
+	cleanup := stefunny.LoggerSetup(&buf, minLevel)
+	t.Cleanup(cleanup)
 }

--- a/versions.go
+++ b/versions.go
@@ -1,0 +1,103 @@
+package stefunny
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+type VersionsOption struct {
+	Format       string `help:"versions list format" default:"table" enum:"table,json,tsv" json:"format,omitempty"`
+	Delete       bool   `help:"delete older versions" default:"false" json:"delete,omitempty"`
+	KeepVersions int    `help:"Number of latest versions to keep. Older versions will be deleted with --delete." default:"5" json:"keep_versions,omitempty"`
+}
+
+type OutputFormatter struct {
+	Data   *ListStateMachineVersionsOutput
+	Format string
+}
+
+func (f OutputFormatter) JSON() string {
+	if f.Data == nil {
+		return "[]"
+	}
+	b, _ := json.Marshal(f.Data.Versions)
+	var out bytes.Buffer
+	json.Indent(&out, b, "", "  ")
+	return out.String()
+}
+
+func (f OutputFormatter) TSV() string {
+	buf := new(strings.Builder)
+	for _, v := range f.Data.Versions {
+		buf.WriteString(strings.Join([]string{
+			fmt.Sprintf("%d", v.Version),
+			strings.Join(v.Aliases, ","),
+			v.CreationDate.Local().Format(time.RFC3339),
+			v.RevisionID,
+			v.Description,
+		}, "\t") + "\n")
+	}
+	return buf.String()
+}
+
+func (f OutputFormatter) Table() string {
+	buf := new(strings.Builder)
+	w := tablewriter.NewWriter(buf)
+	w.SetHeader([]string{"Version", "Aliases", "Creation Date", "Revision ID", "Description"})
+	for _, v := range f.Data.Versions {
+		w.Append([]string{
+			fmt.Sprintf("%d", v.Version),
+			strings.Join(v.Aliases, ","),
+			v.CreationDate.Local().Format(time.RFC3339),
+			v.RevisionID,
+			v.Description,
+		})
+	}
+	w.Render()
+	return buf.String()
+}
+
+func (f OutputFormatter) String() string {
+	switch f.Format {
+	case "json":
+		return f.JSON()
+	case "tsv":
+		return f.TSV()
+	default:
+		return f.Table()
+	}
+}
+
+func (app *App) Versions(ctx context.Context, opt VersionsOption) error {
+	stateMachine, err := app.sfnSvc.DescribeStateMachine(ctx, app.cfg.StateMachineName())
+	if err != nil {
+		if !errors.Is(err, ErrStateMachineDoesNotExist) {
+			return fmt.Errorf("failed to describe current state machine status: %w", err)
+		}
+		log.Println("[info] State machine does not exist")
+		return nil
+	}
+	if opt.Delete {
+		if err := app.sfnSvc.PurgeStateMachineVersions(ctx, stateMachine, opt.KeepVersions); err != nil {
+			return fmt.Errorf("failed to delete older versions: %w", err)
+		}
+	}
+	versions, err := app.sfnSvc.ListStateMachineVersions(ctx, stateMachine)
+	if err != nil {
+		return fmt.Errorf("failed to list state machine versions: %w", err)
+	}
+	formatter := &OutputFormatter{
+		Data:   versions,
+		Format: opt.Format,
+	}
+	fmt.Println(formatter.String())
+	return nil
+}

--- a/versions.go
+++ b/versions.go
@@ -28,9 +28,16 @@ func (f OutputFormatter) JSON() string {
 	if f.Data == nil {
 		return "[]"
 	}
-	b, _ := json.Marshal(f.Data.Versions)
+	b, err := json.Marshal(f.Data.Versions)
+	if err != nil {
+		log.Printf("[warn] failed to marshal JSON: %v", err)
+		return "[]"
+	}
 	var out bytes.Buffer
-	json.Indent(&out, b, "", "  ")
+	if err := json.Indent(&out, b, "", "  "); err != nil {
+		log.Printf("[warn] failed to indent JSON: %v", err)
+		return string(b)
+	}
 	return out.String()
 }
 


### PR DESCRIPTION
on deploy:
```shell
$ go run cmd/stefunny/main.go deploy --config stefunny.jsonnet       
2024/02/07 11:10:43 [info] Starting deploy 
2024/02/07 11:10:44 [info] update state machine `arn:aws:states:ap-northeast-1:123456789012:stateMachine:Hello:3`
2024/02/07 11:10:44 [info] update current alias `arn:aws:states:ap-northeast-1:123456789012:stateMachine:Hello:current`
2024/02/07 11:10:44 [info] deploy state machine `Hello`(at `2024-02-06 16:43:46.948 +0000 UTC`)
2024/02/07 11:10:44 [info] finish deploy 
```

```shell
 go run cmd/stefunny/main.go deploy --config stefunny.jsonnet --version-description "this is test"
2024/02/07 11:11:47 [info] Starting deploy 
2024/02/07 11:11:48 [info] update state machine `arn:aws:states:ap-northeast-1:123456789012:stateMachine:Hello:4`
2024/02/07 11:11:48 [info] update current alias `arn:aws:states:ap-northeast-1:123456789012:stateMachine:Hello:current`
2024/02/07 11:11:48 [info] deploy state machine `Hello`(at `2024-02-07 02:11:48.495 +0000 UTC`)
2024/02/07 11:11:48 [info] finish deploy 
```

new subcommand `versions` show current version list:
```shell
$ go run cmd/stefunny/main.go versions --config stefunny.jsonnet                             
+---------+---------+---------------------------+--------------------------------------+--------------+
| VERSION | ALIASES |       CREATION DATE       |             REVISION ID              | DESCRIPTION  |
+---------+---------+---------------------------+--------------------------------------+--------------+
|       4 | current | 2024-02-07T11:11:48+09:00 | 8705ac1e-4e1c-47c8-90e9-6c3cf64db7c5 | this is test |
|       3 |         | 2024-02-07T01:43:46+09:00 | bb897394-d6b6-401b-9c71-53062aafb0aa | v2           |
|       1 |         | 2024-02-07T01:42:55+09:00 |                                      | rwea         |
+---------+---------+---------------------------+--------------------------------------+--------------+
```

on rollback:
```shell
$ go run cmd/stefunny/main.go rollback --config stefunny.jsonnet
2024/02/07 11:13:54 [info] Starting rollback arn:aws:states:ap-northeast-1:123456789012:stateMachine:Hello 
2024/02/07 11:13:54 [info] current alias version is `4`
2024/02/07 11:13:55 [info] rollback to version `3`
2024/02/07 11:13:55 [info] update current alias `arn:aws:states:ap-northeast-1:123456789012:stateMachine:Hello:current`
2024/02/07 11:13:55 [info] rollback success
2024/02/07 11:13:55 [info] deleting version `4`
2024/02/07 11:13:55 [info] `arn:aws:states:ap-northeast-1:123456789012:stateMachine:Hello:4` deleted
2024/02/07 11:13:55 [info] finish rollback arn:aws:states:ap-northeast-1:123456789012:stateMachine:Hello `
```

after rollback versions output:
```shell
$ go run cmd/stefunny/main.go versions --config my-local/stefunny.jsonnet
+---------+---------+---------------------------+--------------------------------------+-------------+
| VERSION | ALIASES |       CREATION DATE       |             REVISION ID              | DESCRIPTION |
+---------+---------+---------------------------+--------------------------------------+-------------+
|       3 | current | 2024-02-07T01:43:46+09:00 | bb897394-d6b6-401b-9c71-53062aafb0aa | v2          |
|       1 |         | 2024-02-07T01:42:55+09:00 |                                      | rwea        |
+---------+---------+---------------------------+--------------------------------------+-------------+
```