### PR TITLE
suppression TFState Lookup Listup warn

### DIFF
--- a/tfstate.go
+++ b/tfstate.go
@@ -83,10 +83,19 @@ var (
 	ignoreResourceSuffix = []string{
 		"_policy",
 	}
+	ignoreResourcePrefix = []string{
+		"aws_cloudwatch_event_target",
+	}
 )
 
 func lookupResourceKey(resourcePrefix string, data map[string]any) (map[string]string, bool) {
 	parts := strings.Split(resourcePrefix, ".")
+	for _, prefix := range ignoreResourcePrefix {
+		if strings.HasPrefix(parts[0], prefix) {
+			log.Printf("[debug] ignore `%s` reason is has prefix `%s`", resourcePrefix, prefix)
+			return nil, false
+		}
+	}
 	for _, suffix := range ignoreResourceSuffix {
 		if strings.HasSuffix(parts[0], suffix) {
 			log.Printf("[debug] ignore `%s` reason is has suffix `%s`", resourcePrefix, suffix)

--- a/tfstate.go
+++ b/tfstate.go
@@ -62,6 +62,9 @@ func newResourcesReverseMapFromTFState(s *tfstate.TFState, list []string) (map[s
 			continue
 		}
 		for value, key := range reverseMap {
+			if strings.TrimSpace(value) == "" {
+				continue
+			}
 			if duplicated, ok := resources[value]; ok {
 				switch {
 				case strings.HasPrefix(duplicated, "data."):


### PR DESCRIPTION
suppression this warn

```
2024/03/08 11:02:33 [warn] `arn:aws:sns:ap-northeast-1:123456789012:nowpaste` is duplicated (`aws_cloudwatch_event_target.nowpaste.arn` and `aws_sns_topic.nowpaste.arn`), skip after key
2024/03/08 11:02:33 [warn] `arn:aws:acm:us-east-1:123456789012:certificate/0000000-0000-0000-0000-0000000000` is duplicated (`aws_acm_certificate.main_cert_us_east_1.arn` and `data.aws_acm_certificate.cert.arn`), skip after key
```

rule1. ignore aws_cloudwatch_event_target resource
rule2. data.hoge.* and hoge.* , remove data.hoge.*