### PR TITLE
fix panic: care no version arn

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -64,6 +64,9 @@ func extructVersion(versionArn string) (int, error) {
 	if len(parts) < 2 {
 		return 0, fmt.Errorf("invalid arn format: %s", versionArn)
 	}
+	if len(parts) == 2 {
+		return 0, nil
+	}
 	version, err := strconv.Atoi(parts[2])
 	if err != nil {
 		return 0, fmt.Errorf("parse version number failed: %w", err)
@@ -72,7 +75,7 @@ func extructVersion(versionArn string) (int, error) {
 }
 
 func addQualifierToArn(arnStr string, name string) string {
-	if name == "" {
+	if name == "" || name == "0" {
 		return arnStr
 	}
 	return fmt.Sprintf("%s:%s", arnStr, name)


### PR DESCRIPTION
```
$stefunny status --latest --ext-str ENV=dev --ext-str AWS_REGION=ap-northeast-1
panic: runtime error: index out of range [2] with length 2

goroutine 1 [running]:
github.com/mashiike/stefunny.extructVersion({0x14000798820, 0x4c})
        /home/runner/work/stefunny/stefunny/utils.go:67 +0x250
github.com/mashiike/stefunny.(*App).newStateMachineStatus(0x14000435040, {0x101475080, 0x1400047a480}, {0x0, 0x0})
        /home/runner/work/stefunny/stefunny/status.go:61 +0x16c
github.com/mashiike/stefunny.(*App).Status(0x14000435040, {0x101475080, 0x1400047a480}, {{0x140006c83a0?, 0x1400035fc48?}, 0xa0?})
        /home/runner/work/stefunny/stefunny/status.go:22 +0x58
github.com/mashiike/stefunny.(*CLI).Run(0x14000445b80, {0x101475080, 0x1400047a480}, {0x1400003a0a0?, 0x4?, 0x140000021a0?})
        /home/runner/work/stefunny/stefunny/cli.go:260 +0x5b4
main.main()
        /home/runner/work/stefunny/stefunny/cmd/stefunny/main.go:18 +0x25c
make: *** [status-latest/hourly-dbt-build] Error 2
```