### PR TITLE
Fix Deprecated

### DIFF
--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -19,7 +19,7 @@ jobs:
           golangci_lint_flags: "--config=.golangci.yaml"
           filter_mode: diff_context
           reporter: github-pr-review
-          fail_on_error: true
+          fail_level: error
 
   actionlint:
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
         with:
           reporter: github-pr-review
           filter_mode: diff_context
-          fail_on_error: true
+          fail_level: error
 
   misspell:
     runs-on: ubuntu-latest
@@ -40,7 +40,7 @@ jobs:
           reporter: github-pr-review
           level: warning
           filter_mode: diff_context
-          fail_on_error: true
+          fail_level: error
           exclude: |
             ./.git/*
             ./.cache/*

--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           level: warning
-          golangci_lint_flags: "--config=.golangci.yaml"
+          golangci_lint_flags: "--config=.golangci.yaml --timeout 5m"
           filter_mode: diff_context
           reporter: github-pr-review
           fail_level: error

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,8 @@ linters-settings:
       - '[c|C]ommit'
       - '[r|R]ollback'
       - '[p|P]rintln'
-
+      - 'io.WriteString'
+      - 'bufio.Writer.WriteRune'
 linters:
   disable-all: true
   enable:

--- a/app.go
+++ b/app.go
@@ -7,9 +7,6 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
-	"github.com/aws/aws-sdk-go-v2/service/scheduler"
-	"github.com/aws/aws-sdk-go-v2/service/sfn"
 )
 
 const (
@@ -47,7 +44,7 @@ func (o *newAppOptions) GetSFnService(ctx context.Context) (SFnService, error) {
 	if err != nil {
 		return nil, err
 	}
-	client := sfn.NewFromConfig(awsCfg)
+	client := o.cfg.NewStepFunctionsClientFromConfig(awsCfg)
 	o.sfnSvc = NewSFnService(client)
 	return o.sfnSvc, nil
 }
@@ -62,7 +59,7 @@ func (o *newAppOptions) GetEventBridgeService(ctx context.Context) (EventBridgeS
 	if err != nil {
 		return nil, err
 	}
-	client := eventbridge.NewFromConfig(awsCfg)
+	client := o.cfg.NewEventBridgeClientFromConfig(awsCfg)
 	o.eventbridgeSvc = NewEventBridgeService(client)
 	return o.eventbridgeSvc, nil
 }
@@ -77,7 +74,7 @@ func (o *newAppOptions) GetSchedulerService(ctx context.Context) (SchedulerServi
 	if err != nil {
 		return nil, err
 	}
-	client := scheduler.NewFromConfig(awsCfg)
+	client := o.cfg.NewSchedulerClientFromConfig(awsCfg)
 	o.schedulerSvc = NewSchedulerService(client)
 	return o.schedulerSvc, nil
 }


### PR DESCRIPTION
This pull request includes significant changes to the configuration and client creation for AWS services, as well as updates to the GitHub Actions workflows. The main focus is on refactoring the way AWS clients are instantiated and adding new configurations for the scheduler service.

### AWS Client Refactoring:
* [`config.go`](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L954-R999): Introduced new methods to create AWS clients (`NewStsClientFromConfig`, `NewCloudWatchLogsClientFromConfig`, `NewEventBridgeClientFromConfig`, `NewStepFunctionsClientFromConfig`, `NewSchedulerClientFromConfig`) to replace direct instantiation with `NewFromConfig`. [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L954-R999) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L713-R719) [[3]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R579) [[4]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L428-R428)
* [`app.go`](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL50-R47): Updated methods to use the new client creation methods for Step Functions, EventBridge, and Scheduler services. [[1]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL50-R47) [[2]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL65-R62) [[3]](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL80-R77)

### GitHub Actions Workflow Updates:
* [`.github/workflows/reviewdog.yaml`](diffhunk://#diff-6c354b3fdaec7d51f8a286043c48990bdbf68c6dcc16568c20db251b40be535cL19-R22): Changed `fail_on_error` to `fail_level: error` and added a timeout to `golangci_lint_flags`. [[1]](diffhunk://#diff-6c354b3fdaec7d51f8a286043c48990bdbf68c6dcc16568c20db251b40be535cL19-R22) [[2]](diffhunk://#diff-6c354b3fdaec7d51f8a286043c48990bdbf68c6dcc16568c20db251b40be535cL32-R32) [[3]](diffhunk://#diff-6c354b3fdaec7d51f8a286043c48990bdbf68c6dcc16568c20db251b40be535cL43-R43)

### Linter Configuration:
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5L14-R15): Added new patterns to the `linters-settings` section.

### Import Cleanup:
* [`app.go`](diffhunk://#diff-6c4b6ed7dc8834cef100f50dae61c30ffe7775a3f3f6f5a557517cb740c44a2dL10-L12): Removed unused imports for AWS services.